### PR TITLE
Add role-based dashboards and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "amk-portal3.0",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.22"
+        "vue": "^3.5.22",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -1434,6 +1435,12 @@
         "@vue/shared": "3.5.22"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/devtools-core": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.2.tgz",
@@ -2789,6 +2796,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.22"
+    "vue": "^3.5.22",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,47 +1,13 @@
-<script setup>
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
-</script>
-
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-    </div>
-  </header>
-
-  <main>
-    <TheWelcome />
-  </main>
+  <RouterView />
 </template>
 
+<script setup>
+import { RouterView } from 'vue-router'
+</script>
+
 <style scoped>
-header {
-  line-height: 1.5;
-}
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
+:global(body) {
+  margin: 0;
 }
 </style>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,35 +1,25 @@
 @import './base.css';
 
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%);
+  color: #e2e8f0;
+}
+
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  font-weight: normal;
+  min-height: 100vh;
+  width: 100%;
 }
 
-a,
-.green {
-  text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
-  transition: 0.4s;
-  padding: 3px;
+a {
+  color: #93c5fd;
 }
 
-@media (hover: hover) {
-  a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
-  }
+a:hover {
+  color: #bfdbfe;
 }
 
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-  }
+button {
+  font: inherit;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,10 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+
+app.use(router)
+
+app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,73 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+const roleRouteMap = {
+  admin: { name: 'admin-dashboard', path: '/dashboard/admin' },
+  pegawai: { name: 'pegawai-dashboard', path: '/dashboard/pegawai' },
+  officer: { name: 'officer-dashboard', path: '/dashboard/officer' }
+}
+
+const routes = [
+  {
+    path: '/',
+    name: 'login',
+    component: () => import('../views/LoginView.vue')
+  },
+  {
+    path: '/dashboard/admin',
+    name: 'admin-dashboard',
+    meta: { requiresAuth: true, role: 'admin' },
+    component: () => import('../views/AdminDashboard.vue')
+  },
+  {
+    path: '/dashboard/pegawai',
+    name: 'pegawai-dashboard',
+    meta: { requiresAuth: true, role: 'pegawai' },
+    component: () => import('../views/PegawaiDashboard.vue')
+  },
+  {
+    path: '/dashboard/officer',
+    name: 'officer-dashboard',
+    meta: { requiresAuth: true, role: 'officer' },
+    component: () => import('../views/OfficerDashboard.vue')
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+router.beforeEach((to, from, next) => {
+  if (typeof window === 'undefined') {
+    next()
+    return
+  }
+
+  const rawUser = window.localStorage.getItem('authUser')
+  const user = rawUser ? JSON.parse(rawUser) : null
+
+  if (to.name === 'login' && user?.role) {
+    const target = roleRouteMap[user.role]
+    if (target) {
+      next({ name: target.name })
+      return
+    }
+  }
+
+  if (to.meta?.requiresAuth && !user) {
+    next({ name: 'login' })
+    return
+  }
+
+  if (to.meta?.requiresAuth && user?.role && to.meta.role !== user.role) {
+    const target = roleRouteMap[user.role]
+    if (target) {
+      next({ name: target.name })
+      return
+    }
+  }
+
+  next()
+})
+
+export default router

--- a/src/views/AdminDashboard.vue
+++ b/src/views/AdminDashboard.vue
@@ -1,0 +1,782 @@
+<template>
+  <div class="dashboard-layout">
+    <aside class="sidebar">
+      <div class="sidebar__brand">
+        <div class="brand-initial">AMK</div>
+        <div>
+          <h2>Admin Center</h2>
+          <p>Kelola seluruh aktivitas perusahaan.</p>
+        </div>
+      </div>
+
+      <nav class="sidebar__nav">
+        <a class="nav-link" href="#dashboard">Dashboard</a>
+        <a class="nav-link" href="#pegawai">Pegawai</a>
+        <a class="nav-link" href="#slip-gaji">Slip Gaji</a>
+      </nav>
+
+      <div class="sidebar__meta">
+        <div class="user-role">
+          <span class="label">Peran</span>
+          <span class="value">{{ user.role?.toUpperCase() || 'ADMIN' }}</span>
+        </div>
+        <button class="logout" type="button" @click="logout">Keluar</button>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <header class="content-header" id="dashboard">
+        <div>
+          <p class="greeting">{{ greeting }}</p>
+          <h1>Dashboard Admin</h1>
+          <p class="subtitle">
+            Selamat datang, {{ user.name }}. Berikut ringkasan kinerja untuk periode
+            {{ reportingPeriod }}.
+          </p>
+        </div>
+        <div class="period">
+          <span class="label">Periode Laporan</span>
+          <strong>{{ reportingPeriod }}</strong>
+        </div>
+      </header>
+
+      <section class="summary-grid">
+        <article v-for="card in summaryCards" :key="card.title" class="summary-card">
+          <div class="card-title">{{ card.title }}</div>
+          <div class="card-value">{{ formatNumber(card.value) }}</div>
+          <div class="card-caption">{{ card.caption }}</div>
+          <div class="card-highlight">{{ card.highlight }}</div>
+        </article>
+      </section>
+
+      <section id="pegawai" class="panel">
+        <header class="panel__header">
+          <div>
+            <h2>Data Pegawai</h2>
+            <p>Kelola dan pantau data pegawai secara cepat dan akurat.</p>
+          </div>
+          <div class="panel__meta">{{ filteredEmployees.length }} dari {{ employees.length }} pegawai</div>
+        </header>
+
+        <div class="search-bar">
+          <input
+            v-model="searchTerm"
+            type="search"
+            placeholder="Cari nama, divisi, atau jabatan..."
+            aria-label="Cari pegawai"
+          />
+        </div>
+
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Nama</th>
+                <th>Divisi</th>
+                <th>Jabatan</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="employee in filteredEmployees" :key="employee.id">
+                <td>
+                  <div class="cell-primary">{{ employee.name }}</div>
+                  <div class="cell-secondary">{{ employee.id }}</div>
+                </td>
+                <td>{{ employee.department }}</td>
+                <td>{{ employee.position }}</td>
+                <td>
+                  <span class="status" :class="employee.status.toLowerCase()">{{ employee.status }}</span>
+                </td>
+              </tr>
+              <tr v-if="!filteredEmployees.length">
+                <td class="empty" colspan="4">Pegawai tidak ditemukan untuk kata kunci tersebut.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="slip-gaji" class="panel">
+        <header class="panel__header">
+          <div>
+            <h2>Status Slip Gaji</h2>
+            <p>Monitor proses distribusi slip gaji untuk memastikan seluruh pegawai menerima tepat waktu.</p>
+          </div>
+          <div class="panel__meta">Terakhir diperbarui {{ lastBatch }}</div>
+        </header>
+
+        <div class="slip-grid">
+          <div class="slip-progress">
+            <div class="progress-ring">
+              <svg viewBox="0 0 120 120">
+                <circle class="track" cx="60" cy="60" r="54" />
+                <circle
+                  class="indicator"
+                  cx="60"
+                  cy="60"
+                  r="54"
+                  :stroke-dasharray="circumference"
+                  :stroke-dashoffset="circumference - (circumference * slipCompletion) / 100"
+                />
+              </svg>
+              <div class="progress-value">
+                <strong>{{ slipCompletion }}%</strong>
+                <span>Terkirim</span>
+              </div>
+            </div>
+            <p class="progress-caption">
+              {{ formatNumber(salaryStats.sent) }} dari {{ formatNumber(totalSlips) }} slip gaji telah
+              berhasil dikirimkan.
+            </p>
+          </div>
+
+          <ul class="slip-list">
+            <li v-for="stat in slipBreakdown" :key="stat.label">
+              <div class="dot" :style="{ backgroundColor: stat.color }"></div>
+              <div>
+                <div class="label">{{ stat.label }}</div>
+                <div class="value">{{ formatNumber(stat.value) }} slip</div>
+                <small>{{ stat.description }}</small>
+              </div>
+              <span class="percentage">{{ stat.percentage }}%</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const defaultUser = {
+  name: 'Administrator',
+  email: 'admin@amk.test',
+  role: 'admin'
+}
+
+const user = ref(defaultUser)
+
+if (typeof window !== 'undefined') {
+  const raw = window.localStorage.getItem('authUser')
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw)
+      user.value = { ...defaultUser, ...parsed }
+    } catch (error) {
+      user.value = defaultUser
+    }
+  }
+}
+
+const employees = ref([
+  { id: 'AMK-001', name: 'Rina Pratama', department: 'Keuangan', position: 'Finance Analyst', status: 'Aktif' },
+  { id: 'AMK-002', name: 'Budi Santosa', department: 'Operasional', position: 'Supervisor Operasional', status: 'Aktif' },
+  { id: 'AMK-003', name: 'Siti Rahmawati', department: 'Human Capital', position: 'HR Specialist', status: 'Cuti' },
+  { id: 'AMK-004', name: 'Andi Wijaya', department: 'Teknologi', position: 'Software Engineer', status: 'Aktif' },
+  { id: 'AMK-005', name: 'Maria Jelita', department: 'Pemasaran', position: 'Brand Strategist', status: 'Aktif' },
+  { id: 'AMK-006', name: 'Fajar Nugraha', department: 'Operasional', position: 'Field Officer', status: 'Mutasi' }
+])
+
+const salaryStats = ref({
+  sent: 128,
+  pending: 5,
+  issues: 2,
+  lastBatch: '2025-01-20T09:00:00+07:00'
+})
+
+const searchTerm = ref('')
+
+const filteredEmployees = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
+  if (!keyword) {
+    return employees.value
+  }
+
+  return employees.value.filter((employee) => {
+    const haystack = `${employee.name} ${employee.department} ${employee.position}`.toLowerCase()
+    return haystack.includes(keyword)
+  })
+})
+
+const reportingPeriod = computed(() =>
+  new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' }).format(new Date())
+)
+
+const currentMonthName = computed(() =>
+  new Intl.DateTimeFormat('id-ID', { month: 'long' }).format(new Date())
+)
+
+const summaryCards = computed(() => [
+  {
+    title: 'Pegawai Terdaftar',
+    value: employees.value.length,
+    caption: `Aktif per ${reportingPeriod.value}`,
+    highlight: 'Naik 4 pegawai dibanding bulan lalu'
+  },
+  {
+    title: 'Slip Gaji Terkirim',
+    value: salaryStats.value.sent,
+    caption: `Periode ${reportingPeriod.value}`,
+    highlight: '98% dari target distribusi'
+  },
+  {
+    title: 'Slip Gaji Menunggu',
+    value: salaryStats.value.pending,
+    caption: 'Perlu tindak lanjut tim HR',
+    highlight: `Selesaikan sebelum 25 ${currentMonthName.value}`
+  },
+  {
+    title: 'Slip Perlu Koreksi',
+    value: salaryStats.value.issues,
+    caption: 'Butuh verifikasi ulang',
+    highlight: 'Prioritaskan penanganan segera'
+  }
+])
+
+const totalSlips = computed(() =>
+  salaryStats.value.sent + salaryStats.value.pending + salaryStats.value.issues
+)
+
+const slipBreakdown = computed(() => {
+  const total = totalSlips.value || 1
+  return [
+    {
+      label: 'Slip Gaji Terkirim',
+      value: salaryStats.value.sent,
+      color: '#34d399',
+      percentage: Math.round((salaryStats.value.sent / total) * 100),
+      description: 'Sudah diterima seluruh pegawai'
+    },
+    {
+      label: 'Menunggu Persetujuan',
+      value: salaryStats.value.pending,
+      color: '#fbbf24',
+      percentage: Math.round((salaryStats.value.pending / total) * 100),
+      description: 'Dalam proses verifikasi'
+    },
+    {
+      label: 'Perlu Koreksi',
+      value: salaryStats.value.issues,
+      color: '#f87171',
+      percentage: Math.round((salaryStats.value.issues / total) * 100),
+      description: 'Menunggu revisi slip'
+    }
+  ]
+})
+
+const circumference = 2 * Math.PI * 54
+
+const slipCompletion = computed(() => Math.round((salaryStats.value.sent / (totalSlips.value || 1)) * 100))
+
+const lastBatch = computed(() =>
+  new Intl.DateTimeFormat('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(salaryStats.value.lastBatch))
+)
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Selamat pagi'
+  if (hour < 15) return 'Selamat siang'
+  if (hour < 18) return 'Selamat sore'
+  return 'Selamat malam'
+})
+
+const formatNumber = (value) => new Intl.NumberFormat('id-ID').format(value)
+
+const logout = () => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem('authUser')
+  }
+  router.push({ name: 'login' })
+}
+</script>
+
+<style scoped>
+.dashboard-layout {
+  min-height: 100vh;
+  display: flex;
+  color: #e2e8f0;
+}
+
+.sidebar {
+  width: 280px;
+  background: rgba(15, 23, 42, 0.85);
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+}
+
+.sidebar__brand {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.brand-initial {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.sidebar__brand h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #f8fafc;
+}
+
+.sidebar__brand p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.45);
+  color: #e2e8f0;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.nav-link:hover {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(37, 99, 235, 0.3);
+}
+
+.sidebar__meta {
+  margin-top: auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.user-role {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.user-role .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.user-role .value {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.logout {
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: #fca5a5;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.logout:hover {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.main-content {
+  flex: 1;
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.content-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.greeting {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.content-header h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  color: #f8fafc;
+}
+
+.subtitle {
+  max-width: 560px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.period {
+  padding: 1rem;
+  background: rgba(30, 41, 59, 0.45);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: right;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.period .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.summary-card {
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.5rem;
+  min-height: 160px;
+}
+
+.card-title {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.card-value {
+  font-size: clamp(1.6rem, 2.5vw, 2.2rem);
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.card-caption {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.card-highlight {
+  font-size: 0.9rem;
+  color: #93c5fd;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  max-width: 560px;
+}
+
+.panel__meta {
+  padding: 0.6rem 1rem;
+  background: rgba(30, 41, 59, 0.55);
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.search-bar input {
+  width: 100%;
+  height: 48px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  color: #f8fafc;
+  padding: 0 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-bar input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.2);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+th,
+td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.cell-primary {
+  font-weight: 600;
+}
+
+.cell-secondary {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 96px;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: rgba(96, 165, 250, 0.15);
+  border: 1px solid rgba(96, 165, 250, 0.4);
+}
+
+.status.cuti {
+  background: rgba(250, 204, 21, 0.15);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #fde68a;
+}
+
+.status.mutasi {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.empty {
+  text-align: center;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.slip-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+}
+
+.slip-progress {
+  display: grid;
+  gap: 1rem;
+}
+
+.progress-ring {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  margin: 0 auto;
+}
+
+.progress-ring svg {
+  width: 140px;
+  height: 140px;
+}
+
+.track {
+  fill: none;
+  stroke: rgba(148, 163, 184, 0.25);
+  stroke-width: 12;
+}
+
+.indicator {
+  fill: none;
+  stroke: url(#progressGradient);
+  stroke: #38bdf8;
+  stroke-width: 12;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+.progress-value {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 0.25rem;
+}
+
+.progress-value strong {
+  font-size: 1.8rem;
+  color: #f8fafc;
+}
+
+.progress-value span {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.progress-caption {
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.9rem;
+}
+
+.slip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.slip-list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.slip-list .label {
+  font-weight: 600;
+}
+
+.slip-list .value {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.percentage {
+  font-weight: 600;
+  color: #93c5fd;
+}
+
+@media (max-width: 1080px) {
+  .dashboard-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    position: relative;
+    max-height: none;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .nav-link {
+    text-align: center;
+  }
+
+  .sidebar__meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 960px) {
+  .slip-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .progress-caption {
+    text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar__meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel__header {
+    flex-direction: column;
+  }
+
+  table {
+    min-width: 100%;
+  }
+}
+</style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,279 @@
+<template>
+  <div class="auth-wrapper">
+    <div class="auth-card">
+      <div class="brand-area">
+        <h1>AMK Portal 3.0</h1>
+        <p>Masuk menggunakan akun yang sesuai dengan peran Anda untuk mengakses dashboard personal.</p>
+      </div>
+
+      <form class="auth-form" @submit.prevent="handleLogin">
+        <label class="field">
+          <span>Email</span>
+          <input
+            v-model="email"
+            type="email"
+            placeholder="nama@amk.test"
+            required
+            autocomplete="username"
+          />
+        </label>
+
+        <label class="field">
+          <span>Password</span>
+          <input
+            v-model="password"
+            type="password"
+            placeholder="••••••••"
+            required
+            autocomplete="current-password"
+          />
+        </label>
+
+        <button class="submit" type="submit">
+          Masuk
+        </button>
+
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+      </form>
+
+      <div class="dummy-credentials">
+        <h2>Akun Dummy untuk Pengujian</h2>
+        <p>Klik salah satu untuk mengisi otomatis.</p>
+        <ul>
+          <li v-for="cred in credentials" :key="cred.role">
+            <button type="button" @click="prefillCredential(cred)">
+              <div class="role">{{ cred.name }} ({{ cred.role }})</div>
+              <div class="email">{{ cred.email }}</div>
+              <div class="password">{{ cred.password }}</div>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const email = ref('')
+const password = ref('')
+const errorMessage = ref('')
+
+const credentials = [
+  {
+    role: 'admin',
+    name: 'Administrator',
+    email: 'admin@amk.test',
+    password: 'admin123'
+  },
+  {
+    role: 'pegawai',
+    name: 'Pegawai',
+    email: 'pegawai@amk.test',
+    password: 'pegawai123'
+  },
+  {
+    role: 'officer',
+    name: 'Officer',
+    email: 'officer@amk.test',
+    password: 'officer123'
+  }
+]
+
+const roleRouteMap = {
+  admin: '/dashboard/admin',
+  pegawai: '/dashboard/pegawai',
+  officer: '/dashboard/officer'
+}
+
+const handleLogin = () => {
+  errorMessage.value = ''
+  const user = credentials.find(
+    (cred) =>
+      cred.email === email.value.trim().toLowerCase() && cred.password === password.value.trim()
+  )
+
+  if (!user) {
+    errorMessage.value = 'Email atau password tidak valid. Silakan coba lagi.'
+    return
+  }
+
+  const authUser = {
+    role: user.role,
+    name: user.name,
+    email: user.email
+  }
+
+  window.localStorage.setItem('authUser', JSON.stringify(authUser))
+  router.push(roleRouteMap[user.role])
+}
+
+const prefillCredential = (cred) => {
+  email.value = cred.email
+  password.value = cred.password
+  errorMessage.value = ''
+}
+</script>
+
+<style scoped>
+.auth-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.auth-card {
+  width: min(960px, 100%);
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 24px;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.brand-area h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: #f8fafc;
+}
+
+.brand-area p {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.field input {
+  height: 48px;
+  padding: 0 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  color: #f8fafc;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.2);
+}
+
+.submit {
+  height: 48px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+}
+
+.error-message {
+  margin-top: 0.25rem;
+  color: #fca5a5;
+  font-size: 0.9rem;
+}
+
+.dummy-credentials {
+  background: rgba(30, 41, 59, 0.5);
+  border-radius: 18px;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.dummy-credentials h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.35rem;
+  color: #f1f5f9;
+}
+
+.dummy-credentials p {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+  margin-bottom: 0.75rem;
+}
+
+.dummy-credentials ul {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.dummy-credentials li button {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.55);
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.dummy-credentials li button:hover {
+  border-color: rgba(96, 165, 250, 0.6);
+  background: rgba(30, 64, 175, 0.35);
+}
+
+.dummy-credentials .role {
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.dummy-credentials .email,
+.dummy-credentials .password {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+@media (min-width: 960px) {
+  .auth-card {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+
+  .auth-form {
+    align-self: stretch;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 1.5rem;
+  }
+
+  .dummy-credentials li button {
+    font-size: 0.85rem;
+  }
+}
+</style>

--- a/src/views/OfficerDashboard.vue
+++ b/src/views/OfficerDashboard.vue
@@ -1,0 +1,398 @@
+<template>
+  <div class="dashboard-layout">
+    <aside class="sidebar">
+      <div class="sidebar__brand">
+        <div class="brand-initial">AMK</div>
+        <div>
+          <h2>Officer Panel</h2>
+          <p>Pantau aktivitas operasional dan tugas lapangan.</p>
+        </div>
+      </div>
+
+      <nav class="sidebar__nav">
+        <a class="nav-link" href="#ringkasan">Ringkasan</a>
+        <a class="nav-link" href="#penugasan">Penugasan</a>
+      </nav>
+
+      <div class="sidebar__meta">
+        <div class="user-role">
+          <span class="label">Nama</span>
+          <span class="value">{{ user.name }}</span>
+        </div>
+        <button class="logout" type="button" @click="logout">Keluar</button>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <header class="content-header" id="ringkasan">
+        <div>
+          <p class="greeting">{{ greeting }}</p>
+          <h1>Dashboard Officer</h1>
+          <p class="subtitle">
+            Modul analitik officer akan segera hadir. Sementara itu, gunakan halaman ini untuk
+            memantau catatan dan kebutuhan operasional terbaru.
+          </p>
+        </div>
+        <div class="period">
+          <span class="label">Status</span>
+          <strong>Pengembangan</strong>
+        </div>
+      </header>
+
+      <section class="panel placeholder">
+        <header class="panel__header">
+          <div>
+            <h2>Segera Hadir</h2>
+            <p>Fitur penugasan lapangan, monitoring SLA, dan pelaporan real-time akan ditambahkan di sini.</p>
+          </div>
+        </header>
+
+        <div class="placeholder-grid">
+          <article class="placeholder-card">
+            <h3>Penugasan Harian</h3>
+            <p>Kelola distribusi tugas dan pantau progres harian tim officer.</p>
+          </article>
+          <article class="placeholder-card">
+            <h3>Monitoring Lokasi</h3>
+            <p>Integrasi dengan pelacakan lokasi untuk memastikan kunjungan sesuai jadwal.</p>
+          </article>
+          <article class="placeholder-card">
+            <h3>Catatan Lapangan</h3>
+            <p>Kompilasi catatan lapangan, dokumentasi foto, dan kebutuhan follow-up.</p>
+          </article>
+        </div>
+
+        <div class="info-box">
+          <h3>Butuh fitur tertentu?</h3>
+          <p>
+            Sampaikan kebutuhan Anda kepada tim pengembang agar modul officer dapat disesuaikan dengan
+            alur kerja harian.
+          </p>
+        </div>
+      </section>
+
+      <section class="panel" id="penugasan">
+        <header class="panel__header">
+          <div>
+            <h2>Catatan Sementara</h2>
+            <p>Belum ada data penugasan yang ditampilkan. Fitur ini akan tersedia dalam iterasi berikutnya.</p>
+          </div>
+        </header>
+
+        <div class="empty">Konten belum tersedia.</div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const defaultUser = {
+  name: 'Officer On Duty',
+  email: 'officer@amk.test',
+  role: 'officer'
+}
+
+const user = ref(defaultUser)
+
+if (typeof window !== 'undefined') {
+  const raw = window.localStorage.getItem('authUser')
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw)
+      user.value = { ...defaultUser, ...parsed }
+    } catch (error) {
+      user.value = defaultUser
+    }
+  }
+}
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Selamat pagi'
+  if (hour < 15) return 'Selamat siang'
+  if (hour < 18) return 'Selamat sore'
+  return 'Selamat malam'
+})
+
+const logout = () => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem('authUser')
+  }
+  router.push({ name: 'login' })
+}
+</script>
+
+<style scoped>
+.dashboard-layout {
+  min-height: 100vh;
+  display: flex;
+  color: #e2e8f0;
+}
+
+.sidebar {
+  width: 260px;
+  background: rgba(15, 23, 42, 0.85);
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar__brand {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.brand-initial {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.sidebar__brand h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #f8fafc;
+}
+
+.sidebar__brand p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.45);
+  color: #e2e8f0;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.nav-link:hover {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(37, 99, 235, 0.3);
+}
+
+.sidebar__meta {
+  margin-top: auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.user-role .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.user-role .value {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.logout {
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: #fca5a5;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.logout:hover {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.main-content {
+  flex: 1;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.content-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.greeting {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.content-header h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  color: #f8fafc;
+}
+
+.subtitle {
+  max-width: 580px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.period {
+  padding: 1rem;
+  background: rgba(30, 41, 59, 0.45);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: right;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.period .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  max-width: 560px;
+}
+
+.placeholder-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.placeholder-card {
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.placeholder-card h3 {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.placeholder-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.info-box {
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(30, 64, 175, 0.3);
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.info-box h3 {
+  margin: 0;
+  color: #bfdbfe;
+}
+
+.info-box p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.empty {
+  text-align: center;
+  color: rgba(226, 232, 240, 0.6);
+  padding: 2rem 0;
+}
+
+@media (max-width: 1080px) {
+  .dashboard-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .nav-link {
+    text-align: center;
+  }
+
+  .sidebar__meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar__meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel__header {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/views/PegawaiDashboard.vue
+++ b/src/views/PegawaiDashboard.vue
@@ -1,0 +1,766 @@
+<template>
+  <div class="dashboard-layout">
+    <aside class="sidebar">
+      <div class="sidebar__brand">
+        <div class="brand-initial">AMK</div>
+        <div>
+          <h2>Area Pegawai</h2>
+          <p>Akses biodata dan riwayat slip gaji Anda.</p>
+        </div>
+      </div>
+
+      <nav class="sidebar__nav">
+        <a class="nav-link" href="#biodata">Biodata</a>
+        <a class="nav-link" href="#slip-gaji">Slip Gaji</a>
+      </nav>
+
+      <div class="sidebar__meta">
+        <div class="user-role">
+          <span class="label">Nama</span>
+          <span class="value">{{ user.name }}</span>
+        </div>
+        <button class="logout" type="button" @click="logout">Keluar</button>
+      </div>
+    </aside>
+
+    <main class="main-content">
+      <header class="content-header">
+        <div>
+          <p class="greeting">{{ greeting }}</p>
+          <h1>Dashboard Pegawai</h1>
+          <p class="subtitle">
+            Informasi terbaru mengenai profil dan slip gaji Anda tersedia di sini. Pastikan data
+            Anda selalu terbarui.
+          </p>
+        </div>
+        <div class="period">
+          <span class="label">Slip terbaru</span>
+          <strong>{{ latestSlipLabel }}</strong>
+        </div>
+      </header>
+
+      <section id="biodata" class="panel biodata-panel">
+        <header class="panel__header">
+          <div>
+            <h2>Biodata Pegawai</h2>
+            <p>Ringkasan data personal dan pekerjaan Anda.</p>
+          </div>
+          <div class="panel__meta">Terakhir diperbarui {{ biodata.updatedAt }}</div>
+        </header>
+
+        <div class="biodata-grid">
+          <article v-for="item in biodataItems" :key="item.label" class="biodata-card">
+            <span class="label">{{ item.label }}</span>
+            <span class="value">{{ item.value }}</span>
+            <span v-if="item.hint" class="hint">{{ item.hint }}</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="slip-gaji" class="panel slip-panel">
+        <header class="panel__header">
+          <div>
+            <h2>Slip Gaji</h2>
+            <p>Pilih periode slip gaji yang ingin Anda lihat atau unduh.</p>
+          </div>
+          <div class="filters">
+            <label>
+              <span>Tahun</span>
+              <select v-model="selectedYear">
+                <option v-for="year in availableYears" :key="`year-${year}`" :value="year">
+                  {{ year }}
+                </option>
+              </select>
+            </label>
+            <label>
+              <span>Bulan</span>
+              <select v-model="selectedMonth">
+                <option v-for="month in availableMonths" :key="`month-${month}`" :value="month">
+                  {{ month }}
+                </option>
+              </select>
+            </label>
+          </div>
+        </header>
+
+        <div v-if="activeSlip" class="slip-detail">
+          <div class="detail-grid">
+            <div class="detail-item">
+              <span class="label">Periode</span>
+              <span class="value">{{ selectedMonth }} {{ selectedYear }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Jumlah diterima</span>
+              <span class="value">{{ formatCurrency(activeSlip.amount) }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Status</span>
+              <span class="status" :class="statusClass(activeSlip.status)">{{ activeSlip.status }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Tanggal transfer</span>
+              <span class="value">{{ formatDate(activeSlip.transferDate) }}</span>
+            </div>
+            <div class="detail-item detail-notes">
+              <span class="label">Catatan</span>
+              <span class="value">{{ activeSlip.notes }}</span>
+            </div>
+          </div>
+
+          <div class="slip-actions">
+            <button type="button">Download Slip (PDF)</button>
+            <span>Simulasi — tombol ini belum terhubung ke layanan backend.</span>
+          </div>
+        </div>
+        <p v-else class="empty">Belum ada data slip gaji pada periode yang dipilih.</p>
+
+        <div class="history">
+          <h3>Riwayat Terbaru</h3>
+          <ul>
+            <li v-for="record in condensedHistory" :key="`${record.year}-${record.month}`">
+              <div>
+                <span class="month">{{ record.month }} {{ record.year }}</span>
+                <span class="amount">{{ formatCurrency(record.amount) }}</span>
+              </div>
+              <span class="status" :class="statusClass(record.status)">{{ record.status }}</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const defaultUser = {
+  name: 'Rina Pratama',
+  email: 'pegawai@amk.test',
+  role: 'pegawai'
+}
+
+const user = ref(defaultUser)
+
+if (typeof window !== 'undefined') {
+  const raw = window.localStorage.getItem('authUser')
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw)
+      user.value = { ...defaultUser, ...parsed }
+    } catch (error) {
+      user.value = defaultUser
+    }
+  }
+}
+
+const biodata = {
+  nip: 'AMK-001',
+  department: 'Human Capital',
+  position: 'HR Specialist',
+  joinDate: '12 Januari 2021',
+  grade: 'Senior',
+  phone: '+62 812-3456-7890',
+  status: 'Aktif',
+  updatedAt: '15 Januari 2025'
+}
+
+const biodataItems = computed(() => [
+  { label: 'NIP', value: biodata.nip },
+  { label: 'Divisi', value: biodata.department },
+  { label: 'Jabatan', value: biodata.position },
+  { label: 'Grade', value: biodata.grade },
+  { label: 'Status', value: biodata.status },
+  { label: 'Tanggal Bergabung', value: biodata.joinDate },
+  { label: 'Kontak', value: biodata.phone, hint: 'Perbarui kontak jika terjadi perubahan.' },
+  { label: 'Email', value: user.value.email }
+])
+
+const slipHistory = ref({
+  2025: {
+    Januari: {
+      amount: 8500000,
+      status: 'Terkirim',
+      transferDate: '2025-01-25T09:00:00+07:00',
+      notes: 'Termasuk insentif kinerja Januari.'
+    },
+    Februari: {
+      amount: 8500000,
+      status: 'Terjadwal',
+      transferDate: '2025-02-25T09:00:00+07:00',
+      notes: 'Dalam proses otorisasi keuangan.'
+    }
+  },
+  2024: {
+    Desember: {
+      amount: 8350000,
+      status: 'Terkirim',
+      transferDate: '2024-12-23T09:00:00+07:00',
+      notes: 'Termasuk bonus akhir tahun.'
+    },
+    November: {
+      amount: 8200000,
+      status: 'Terkirim',
+      transferDate: '2024-11-25T09:00:00+07:00',
+      notes: 'Transfer rutin bulanan.'
+    },
+    Oktober: {
+      amount: 8200000,
+      status: 'Terkirim',
+      transferDate: '2024-10-25T09:00:00+07:00',
+      notes: 'Transfer rutin bulanan.'
+    }
+  }
+})
+
+const monthOrder = [
+  'Januari',
+  'Februari',
+  'Maret',
+  'April',
+  'Mei',
+  'Juni',
+  'Juli',
+  'Agustus',
+  'September',
+  'Oktober',
+  'November',
+  'Desember'
+]
+
+const availableYears = computed(() =>
+  Object.keys(slipHistory.value)
+    .sort((a, b) => Number(b) - Number(a))
+)
+
+const selectedYear = ref('')
+const selectedMonth = ref('')
+
+watch(
+  availableYears,
+  (years) => {
+    if (years.length && !years.includes(selectedYear.value)) {
+      selectedYear.value = years[0]
+    }
+  },
+  { immediate: true }
+)
+
+const availableMonths = computed(() => {
+  const data = slipHistory.value[selectedYear.value] || {}
+  return Object.keys(data).sort(
+    (a, b) => monthOrder.indexOf(a) - monthOrder.indexOf(b)
+  )
+})
+
+watch(
+  () => slipHistory.value[selectedYear.value],
+  (records) => {
+    const months = Object.keys(records || {}).sort(
+      (a, b) => monthOrder.indexOf(a) - monthOrder.indexOf(b)
+    )
+    if (months.length && !months.includes(selectedMonth.value)) {
+      selectedMonth.value = months[months.length - 1]
+    }
+    if (!months.length) {
+      selectedMonth.value = ''
+    }
+  },
+  { immediate: true }
+)
+
+const activeSlip = computed(() =>
+  slipHistory.value[selectedYear.value]?.[selectedMonth.value] || null
+)
+
+const condensedHistory = computed(() => {
+  const list = []
+  for (const [year, months] of Object.entries(slipHistory.value)) {
+    for (const [month, detail] of Object.entries(months)) {
+      list.push({
+        year,
+        month,
+        ...detail
+      })
+    }
+  }
+  return list
+    .sort((a, b) => {
+      if (a.year === b.year) {
+        return monthOrder.indexOf(b.month) - monthOrder.indexOf(a.month)
+      }
+      return Number(b.year) - Number(a.year)
+    })
+    .slice(0, 6)
+})
+
+const latestSlipLabel = computed(() => {
+  if (!condensedHistory.value.length) return '-'
+  const latest = condensedHistory.value[0]
+  return `${latest.month} ${latest.year}`
+})
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Selamat pagi'
+  if (hour < 15) return 'Selamat siang'
+  if (hour < 18) return 'Selamat sore'
+  return 'Selamat malam'
+})
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0
+  }).format(value)
+
+const formatDate = (value) =>
+  new Intl.DateTimeFormat('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric'
+  }).format(new Date(value))
+
+const statusClass = (status) => status.toLowerCase().replace(/\s+/g, '-')
+
+const logout = () => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem('authUser')
+  }
+  router.push({ name: 'login' })
+}
+</script>
+
+<style scoped>
+.dashboard-layout {
+  min-height: 100vh;
+  display: flex;
+  color: #e2e8f0;
+}
+
+.sidebar {
+  width: 260px;
+  background: rgba(15, 23, 42, 0.85);
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar__brand {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.brand-initial {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.sidebar__brand h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #f8fafc;
+}
+
+.sidebar__brand p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.45);
+  color: #e2e8f0;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.nav-link:hover {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(37, 99, 235, 0.3);
+}
+
+.sidebar__meta {
+  margin-top: auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.user-role .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.user-role .value {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.logout {
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: #fca5a5;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.logout:hover {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.main-content {
+  flex: 1;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.content-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.greeting {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.content-header h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  color: #f8fafc;
+}
+
+.subtitle {
+  max-width: 560px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.period {
+  padding: 1rem;
+  background: rgba(30, 41, 59, 0.45);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: right;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.period .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  max-width: 520px;
+}
+
+.panel__meta {
+  padding: 0.6rem 1rem;
+  background: rgba(30, 41, 59, 0.55);
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.biodata-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.biodata-card {
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.biodata-card .label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.biodata-card .value {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.biodata-card .hint {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.filters label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.filters select {
+  min-width: 140px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  color: #f8fafc;
+  padding: 0 0.75rem;
+}
+
+.slip-detail {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.detail-item {
+  background: rgba(30, 41, 59, 0.45);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-item .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.detail-item .value {
+  font-weight: 600;
+}
+
+.detail-item.detail-notes {
+  grid-column: span 2;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 96px;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: rgba(96, 165, 250, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.4);
+}
+
+.status.terkirim {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #bbf7d0;
+}
+
+.status.terjadwal,
+.status.proses {
+  background: rgba(250, 204, 21, 0.18);
+  border-color: rgba(250, 204, 21, 0.4);
+  color: #fef3c7;
+}
+
+.slip-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.slip-actions button {
+  height: 44px;
+  padding: 0 1.5rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slip-actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+}
+
+.slip-actions span {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.history h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.history ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.history li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  gap: 1rem;
+}
+
+.history .month {
+  font-weight: 600;
+}
+
+.history .amount {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  margin-left: 0.5rem;
+}
+
+.empty {
+  text-align: center;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+@media (max-width: 1080px) {
+  .dashboard-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .nav-link {
+    text-align: center;
+  }
+
+  .sidebar__meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .detail-item.detail-notes {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sidebar__nav {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar__meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel__header {
+    flex-direction: column;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- integrate Vue Router with role-aware navigation guards and restructure the root app to use routed views
- redesign the login page to match the dashboard visual language and provide dummy credential quick-fill buttons
- add responsive admin, pegawai, and officer dashboards with role-specific layouts, data presentations, and logout handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd697b82888321b880df494ab5b1a8