### PR TITLE
Polish dashboard visuals and overview cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This template should help get you started developing with Vue 3 in Vite.
 
 See [Vite Configuration Reference](https://vite.dev/config/).
 
+## Dummy Accounts
+
+Use the following dummy accounts to test the login flow and akses dashboard yang sesuai dengan peran:
+
+| Role    | Email                    | Password     |
+|---------|--------------------------|--------------|
+| Admin   | `admin@amk-portal.test`  | `Admin123!`  |
+| Pegawai | `pegawai@amk-portal.test`| `Pegawai123!`|
+| Officer | `officer@amk-portal.test`| `Officer123!`|
+
 ## Project Setup
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "amk-portal3.0",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.22"
+        "vue": "^3.5.22",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -1434,6 +1435,12 @@
         "@vue/shared": "3.5.22"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/devtools-core": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.2.tgz",
@@ -2789,6 +2796,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.22"
+    "vue": "^3.5.22",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,47 +1,13 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-    </div>
-  </header>
-
-  <main>
-    <TheWelcome />
-  </main>
+  <RouterView />
 </template>
 
 <style scoped>
-header {
-  line-height: 1.5;
-}
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
+:global(body) {
+  margin: 0;
 }
 </style>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -1,86 +1,44 @@
-/* color palette from <https://github.com/vuejs/theme> */
 :root {
-  --vt-c-white: #ffffff;
-  --vt-c-white-soft: #f8f8f8;
-  --vt-c-white-mute: #f2f2f2;
-
-  --vt-c-black: #181818;
-  --vt-c-black-soft: #222222;
-  --vt-c-black-mute: #282828;
-
-  --vt-c-indigo: #2c3e50;
-
-  --vt-c-divider-light-1: rgba(60, 60, 60, 0.29);
-  --vt-c-divider-light-2: rgba(60, 60, 60, 0.12);
-  --vt-c-divider-dark-1: rgba(84, 84, 84, 0.65);
-  --vt-c-divider-dark-2: rgba(84, 84, 84, 0.48);
-
-  --vt-c-text-light-1: var(--vt-c-indigo);
-  --vt-c-text-light-2: rgba(60, 60, 60, 0.66);
-  --vt-c-text-dark-1: var(--vt-c-white);
-  --vt-c-text-dark-2: rgba(235, 235, 235, 0.64);
-}
-
-/* semantic color variables for this project */
-:root {
-  --color-background: var(--vt-c-white);
-  --color-background-soft: var(--vt-c-white-soft);
-  --color-background-mute: var(--vt-c-white-mute);
-
-  --color-border: var(--vt-c-divider-light-2);
-  --color-border-hover: var(--vt-c-divider-light-1);
-
-  --color-heading: var(--vt-c-text-light-1);
-  --color-text: var(--vt-c-text-light-1);
-
-  --section-gap: 160px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: var(--vt-c-black);
-    --color-background-soft: var(--vt-c-black-soft);
-    --color-background-mute: var(--vt-c-black-mute);
-
-    --color-border: var(--vt-c-divider-dark-2);
-    --color-border-hover: var(--vt-c-divider-dark-1);
-
-    --color-heading: var(--vt-c-text-dark-1);
-    --color-text: var(--vt-c-text-dark-2);
-  }
+  font-family: 'Poppins', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color-scheme: light;
+  color: #f5f7ff;
+  background-color: #05102a;
 }
 
 *,
 *::before,
 *::after {
   box-sizing: border-box;
-  margin: 0;
-  font-weight: normal;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: inherit;
 }
 
 body {
+  margin: 0;
   min-height: 100vh;
-  color: var(--color-text);
-  background: var(--color-background);
-  transition:
-    color 0.5s,
-    background-color 0.5s;
-  line-height: 1.6;
-  font-family:
-    Inter,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    'Fira Sans',
-    'Droid Sans',
-    'Helvetica Neue',
-    sans-serif;
-  font-size: 15px;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  background-color: #05102a;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+::selection {
+  background: rgba(59, 130, 246, 0.45);
+  color: #f5f7ff;
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,35 +1,19 @@
 @import './base.css';
 
+body {
+  font-family: 'Poppins', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #05102a;
+}
+
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  font-weight: normal;
+  min-height: 100vh;
 }
 
-a,
-.green {
-  text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
-  transition: 0.4s;
-  padding: 3px;
-}
-
-@media (hover: hover) {
-  a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
-  }
-}
-
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-  }
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.6rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
 }

--- a/src/components/icons/IconDocument.vue
+++ b/src/components/icons/IconDocument.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M6.5 3h6.25L18 8.25V21H6.5z" />
+    <path d="M12.75 3v5.25H18" />
+    <path d="M9 13h6" />
+    <path d="M9 16.5h6" />
+  </svg>
+</template>

--- a/src/components/icons/IconHome.vue
+++ b/src/components/icons/IconHome.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M3 10.5 12 4l9 6.5" />
+    <path d="M5.5 9.5V20h13V9.5" />
+    <path d="M9.5 20v-5.5h5V20" />
+  </svg>
+</template>

--- a/src/components/icons/IconProfile.vue
+++ b/src/components/icons/IconProfile.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="8" r="4" />
+    <path d="M5 20.5c1.6-2.4 4.1-4 7-4s5.4 1.6 7 4" />
+    <path d="M9.5 12.5h5" />
+  </svg>
+</template>

--- a/src/components/icons/IconUsers.vue
+++ b/src/components/icons/IconUsers.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M16.75 8.5a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+    <path d="M4 20.25a6 6 0 0 1 6-6h4a6 6 0 0 1 6 6" />
+    <path d="M7 8.5a3.5 3.5 0 0 1 .6-1.9" />
+    <path d="M5 20a5.5 5.5 0 0 1 2.4-4.6" />
+  </svg>
+</template>

--- a/src/layouts/DashboardLayout.vue
+++ b/src/layouts/DashboardLayout.vue
@@ -1,0 +1,645 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+defineProps({
+  menuItems: {
+    type: Array,
+    required: true,
+  },
+  pageTitle: {
+    type: String,
+    default: '',
+  },
+  user: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['logout'])
+
+const route = useRoute()
+const isExpanded = ref(false)
+const isMobile = ref(false)
+
+const isCollapsed = computed(() => !isExpanded.value && !isMobile.value)
+
+const showLabels = computed(() => (isMobile.value ? isExpanded.value : !isCollapsed.value))
+
+function toggleSidebar() {
+  if (isMobile.value) {
+    isExpanded.value = !isExpanded.value
+    return
+  }
+
+  isExpanded.value = !isExpanded.value
+}
+
+function closeSidebarOnMobile() {
+  if (isMobile.value) {
+    isExpanded.value = false
+  }
+}
+
+function handleResize() {
+  isMobile.value = window.innerWidth < 992
+
+  if (!isMobile.value && isExpanded.value === false) {
+    // Keep the sidebar collapsed on desktop by default
+    isExpanded.value = false
+  }
+
+  if (isMobile.value) {
+    isExpanded.value = false
+  }
+}
+
+onMounted(() => {
+  handleResize()
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handleResize)
+})
+
+watch(
+  () => route.fullPath,
+  () => {
+    closeSidebarOnMobile()
+  },
+)
+</script>
+
+<template>
+  <div class="dashboard-shell">
+    <aside
+      :class="[
+        'dashboard-sidebar',
+        { 'dashboard-sidebar--expanded': isExpanded, 'dashboard-sidebar--collapsed': isCollapsed },
+      ]"
+    >
+      <div class="sidebar-content">
+        <div class="sidebar-brand">
+          <div class="brand-logo">AMK</div>
+          <div v-if="showLabels" class="brand-text">
+            <span class="brand-title">Portal</span>
+            <span class="brand-subtitle">3.0</span>
+          </div>
+        </div>
+
+        <nav class="sidebar-nav">
+          <RouterLink
+            v-for="item in menuItems"
+            :key="item.label"
+            :to="item.to"
+            class="sidebar-link"
+            :class="{ 'sidebar-link--active': route.name === item.to.name }"
+          >
+            <component :is="item.icon" class="sidebar-icon" aria-hidden="true" />
+            <span v-if="showLabels" class="sidebar-label">{{ item.label }}</span>
+          </RouterLink>
+        </nav>
+      </div>
+    </aside>
+
+    <div class="dashboard-main">
+      <header class="dashboard-topbar">
+        <button type="button" class="menu-toggle" @click="toggleSidebar" aria-label="Toggle menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <div class="topbar-heading">
+          <h1>{{ pageTitle }}</h1>
+          <p>Selamat datang kembali, {{ user.name }}!</p>
+        </div>
+        <div class="topbar-controls">
+          <label class="topbar-search">
+            <span class="sr-only">Cari</span>
+            <input type="search" placeholder="Cari di dashboard" />
+          </label>
+          <button type="button" class="pill-button" aria-label="Ganti bahasa">ID</button>
+        </div>
+        <div class="topbar-user">
+          <div class="user-initials">{{ user.name?.charAt(0) }}</div>
+          <div class="user-meta">
+            <span class="user-name">{{ user.name }}</span>
+            <span class="user-role">{{ user.role }}</span>
+          </div>
+          <button type="button" class="logout-button" @click="emit('logout')">Keluar</button>
+        </div>
+      </header>
+
+      <main class="dashboard-content">
+        <div class="content-container">
+          <slot />
+        </div>
+      </main>
+    </div>
+
+    <transition name="overlay">
+      <div
+        v-if="isMobile && isExpanded"
+        class="mobile-overlay"
+        role="presentation"
+        @click="toggleSidebar"
+      ></div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.dashboard-shell {
+  min-height: 100vh;
+  display: flex;
+  background: radial-gradient(circle at 12% 18%, rgba(59, 130, 246, 0.18), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(14, 116, 144, 0.22), transparent 60%),
+    linear-gradient(180deg, #030a1c 0%, #05102a 100%);
+  color: #f5f7ff;
+  position: relative;
+}
+
+.dashboard-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(165deg, rgba(25, 52, 112, 0.85), rgba(37, 74, 156, 0.68));
+  border-right: 1px solid rgba(148, 163, 255, 0.2);
+  backdrop-filter: blur(28px);
+  transition: width 0.35s ease, transform 0.35s ease;
+  width: 78px;
+  z-index: 20;
+  overflow: hidden;
+  box-shadow: 10px 0 40px rgba(5, 16, 42, 0.45);
+}
+
+.dashboard-sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(200deg, rgba(79, 70, 229, 0.35), transparent 60%);
+  pointer-events: none;
+}
+
+.dashboard-sidebar--expanded {
+  width: 268px;
+}
+
+.dashboard-sidebar--collapsed {
+  width: 78px;
+}
+
+.sidebar-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 1.4rem;
+  gap: 2.4rem;
+  position: relative;
+  z-index: 1;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: #0b1330;
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.brand-title {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  opacity: 0.7;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 1.05rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.35s ease, color 0.35s ease, border 0.35s ease;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+}
+
+.sidebar-link:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(148, 163, 255, 0.35);
+}
+
+.sidebar-link--active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(139, 92, 246, 0.9));
+  border-color: transparent;
+  box-shadow: 0 18px 36px rgba(59, 130, 246, 0.35);
+}
+
+.sidebar-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.sidebar-label {
+  font-size: 0.95rem;
+}
+
+.dashboard-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 2.2rem 2.4rem;
+  gap: 1.8rem;
+  color: #0b1330;
+  position: relative;
+}
+
+.dashboard-main::before,
+.dashboard-main::after {
+  content: '';
+  position: absolute;
+  border-radius: 40%;
+  filter: blur(120px);
+  z-index: 0;
+  opacity: 0.6;
+}
+
+.dashboard-main::before {
+  width: 360px;
+  height: 360px;
+  background: rgba(59, 130, 246, 0.25);
+  top: -120px;
+  right: 15%;
+}
+
+.dashboard-main::after {
+  width: 420px;
+  height: 420px;
+  background: rgba(34, 211, 238, 0.18);
+  bottom: -160px;
+  left: 10%;
+}
+
+.dashboard-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: rgba(248, 250, 255, 0.95);
+  border-radius: 28px;
+  padding: 1.25rem 1.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 35px 60px -25px rgba(5, 16, 42, 0.55);
+  position: sticky;
+  top: 2.2rem;
+  z-index: 5;
+}
+
+.menu-toggle {
+  width: 50px;
+  height: 50px;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: linear-gradient(135deg, rgba(226, 232, 255, 0.9), rgba(203, 213, 255, 0.6));
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: transform 0.25s ease, border 0.25s ease, box-shadow 0.25s ease;
+}
+
+.menu-toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 999px;
+  background: #1e293b;
+}
+
+.menu-toggle:hover {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.5);
+  box-shadow: 0 12px 20px rgba(59, 130, 246, 0.25);
+}
+
+.topbar-heading {
+  flex: 1;
+}
+
+.topbar-heading h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #111e46;
+}
+
+.topbar-heading p {
+  margin: 0.45rem 0 0;
+  color: rgba(15, 23, 42, 0.65);
+  font-size: 0.95rem;
+}
+
+.topbar-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.topbar-search {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(226, 232, 255, 0.6);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.topbar-search input {
+  border: none;
+  background: transparent;
+  width: 180px;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.topbar-search input::placeholder {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.topbar-search input:focus {
+  outline: none;
+}
+
+.topbar-search:focus-within {
+  border-color: rgba(59, 130, 246, 0.5);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.pill-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(99, 102, 241, 0.9));
+  color: #f8fbff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pill-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(79, 70, 229, 0.3);
+}
+
+.topbar-user {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.user-initials {
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(14, 165, 233, 0.82));
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #f8fbff;
+}
+
+.user-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.user-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.user-role {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(30, 41, 59, 0.55);
+}
+
+.logout-button {
+  border: none;
+  border-radius: 14px;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  background: rgba(239, 68, 68, 0.12);
+  color: rgba(185, 28, 28, 0.88);
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease, transform 0.2s ease;
+}
+
+.logout-button:hover {
+  background: rgba(239, 68, 68, 0.22);
+  color: rgba(220, 38, 38, 0.95);
+  transform: translateY(-1px);
+}
+
+.dashboard-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+}
+
+.content-container {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mobile-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 15, 40, 0.55);
+  backdrop-filter: blur(4px);
+  z-index: 15;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.overlay-enter-active,
+.overlay-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.overlay-enter-from,
+.overlay-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 1280px) {
+  .dashboard-main {
+    padding: 2rem 1.8rem;
+  }
+
+  .dashboard-topbar {
+    top: 1.8rem;
+  }
+}
+
+@media (max-width: 1100px) {
+  .topbar-controls {
+    gap: 0.6rem;
+  }
+
+  .topbar-search input {
+    width: 140px;
+  }
+}
+
+@media (max-width: 992px) {
+  .dashboard-shell {
+    flex-direction: column;
+  }
+
+  .dashboard-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    height: 100vh;
+    transform: translateX(-100%);
+    width: 260px;
+    border-right: 1px solid rgba(148, 163, 255, 0.35);
+    border-radius: 0 28px 28px 0;
+    box-shadow: 0 28px 65px rgba(2, 6, 23, 0.55);
+  }
+
+  .dashboard-sidebar--expanded {
+    transform: translateX(0);
+  }
+
+  .dashboard-main {
+    padding: 1.4rem 1.1rem 2rem;
+  }
+
+  .dashboard-topbar {
+    position: static;
+    border-radius: 24px;
+  }
+
+  .topbar-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .topbar-search {
+    flex: 1;
+  }
+
+  .topbar-search input {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .topbar-heading {
+    text-align: left;
+  }
+
+  .topbar-controls {
+    order: 3;
+    gap: 0.75rem;
+  }
+
+  .pill-button {
+    align-self: flex-start;
+  }
+
+  .topbar-user {
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 576px) {
+  .dashboard-main {
+    padding: 1.1rem 0.9rem 1.6rem;
+  }
+
+  .dashboard-topbar {
+    padding: 1rem 1.1rem;
+  }
+
+  .content-container {
+    width: 100%;
+  }
+
+  .menu-toggle {
+    width: 46px;
+    height: 46px;
+  }
+
+  .topbar-heading h1 {
+    font-size: 1.35rem;
+  }
+
+  .logout-button {
+    padding: 0.5rem 0.95rem;
+  }
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,10 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+
+app.use(router)
+
+app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,110 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import LoginView from '@/views/LoginView.vue'
+import AdminDashboard from '@/views/admin/AdminDashboard.vue'
+import AdminOverview from '@/views/admin/AdminOverview.vue'
+import AdminEmployees from '@/views/admin/AdminEmployees.vue'
+import AdminPayslips from '@/views/admin/AdminPayslips.vue'
+import PegawaiDashboard from '@/views/pegawai/PegawaiDashboard.vue'
+import PegawaiBiodata from '@/views/pegawai/PegawaiBiodata.vue'
+import PegawaiPayslips from '@/views/pegawai/PegawaiPayslips.vue'
+import OfficerDashboard from '@/views/officer/OfficerDashboard.vue'
+import OfficerPlaceholder from '@/views/officer/OfficerPlaceholder.vue'
+import { getCurrentUser, getDashboardPathForRole, isAuthenticated } from '@/stores/auth'
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'Login',
+      component: LoginView,
+      meta: { guestOnly: true },
+    },
+    {
+      path: '/dashboard/admin',
+      component: AdminDashboard,
+      meta: { requiresAuth: true, role: 'admin' },
+      children: [
+        {
+          path: '',
+          name: 'AdminHome',
+          component: AdminOverview,
+          meta: { sectionTitle: 'Ringkasan' },
+        },
+        {
+          path: 'pegawai',
+          name: 'AdminEmployees',
+          component: AdminEmployees,
+          meta: { sectionTitle: 'Data Pegawai' },
+        },
+        {
+          path: 'slip-gaji',
+          name: 'AdminPayslips',
+          component: AdminPayslips,
+          meta: { sectionTitle: 'Slip Gaji' },
+        },
+      ],
+    },
+    {
+      path: '/dashboard/pegawai',
+      component: PegawaiDashboard,
+      meta: { requiresAuth: true, role: 'pegawai' },
+      children: [
+        {
+          path: '',
+          name: 'PegawaiBiodata',
+          component: PegawaiBiodata,
+          meta: { sectionTitle: 'Biodata' },
+        },
+        {
+          path: 'slip-gaji',
+          name: 'PegawaiPayslips',
+          component: PegawaiPayslips,
+          meta: { sectionTitle: 'Slip Gaji' },
+        },
+      ],
+    },
+    {
+      path: '/dashboard/officer',
+      component: OfficerDashboard,
+      meta: { requiresAuth: true, role: 'officer' },
+      children: [
+        {
+          path: '',
+          name: 'OfficerHome',
+          component: OfficerPlaceholder,
+          meta: { sectionTitle: 'Dashboard Officer' },
+        },
+      ],
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: '/',
+    },
+  ],
+})
+
+router.beforeEach((to, from, next) => {
+  const user = getCurrentUser()
+
+  if (to.meta.requiresAuth) {
+    if (!isAuthenticated()) {
+      next({ name: 'Login', query: { redirect: to.fullPath } })
+      return
+    }
+
+    if (to.meta.role && user?.role !== to.meta.role) {
+      next({ path: getDashboardPathForRole(user?.role) })
+      return
+    }
+  }
+
+  if (to.meta.guestOnly && user) {
+    next({ path: getDashboardPathForRole(user.role) })
+    return
+  }
+
+  next()
+})
+
+export default router

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,0 +1,106 @@
+import { computed, ref } from 'vue'
+
+const USERS = {
+  'admin@amk-portal.test': {
+    password: 'Admin123!',
+    role: 'admin',
+    name: 'Admin Utama',
+  },
+  'pegawai@amk-portal.test': {
+    password: 'Pegawai123!',
+    role: 'pegawai',
+    name: 'Pegawai Andalan',
+  },
+  'officer@amk-portal.test': {
+    password: 'Officer123!',
+    role: 'officer',
+    name: 'Officer Monitoring',
+  },
+}
+
+const DASHBOARD_PATHS = {
+  admin: '/dashboard/admin',
+  pegawai: '/dashboard/pegawai',
+  officer: '/dashboard/officer',
+}
+
+function getStoredUser() {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const raw = window.localStorage.getItem('amk-portal:user')
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    console.warn('Failed to parse stored user', error)
+    return null
+  }
+}
+
+const currentUser = ref(getStoredUser())
+
+function persistUser(user) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (!user) {
+    window.localStorage.removeItem('amk-portal:user')
+    return
+  }
+
+  window.localStorage.setItem('amk-portal:user', JSON.stringify(user))
+}
+
+export function login(email, password) {
+  const normalizedEmail = email.trim().toLowerCase()
+  const userRecord = USERS[normalizedEmail]
+
+  if (!userRecord || userRecord.password !== password) {
+    throw new Error('Email atau kata sandi salah')
+  }
+
+  const user = {
+    email: normalizedEmail,
+    role: userRecord.role,
+    name: userRecord.name,
+  }
+
+  currentUser.value = user
+  persistUser(user)
+
+  return user
+}
+
+export function logout() {
+  currentUser.value = null
+  persistUser(null)
+}
+
+export function getCurrentUser() {
+  return currentUser.value
+}
+
+export function isAuthenticated() {
+  return Boolean(currentUser.value)
+}
+
+export function getDashboardPathForRole(role) {
+  return DASHBOARD_PATHS[role] || '/'
+}
+
+export function useAuth() {
+  return {
+    currentUser: computed(() => currentUser.value),
+    isAuthenticated: computed(() => Boolean(currentUser.value)),
+    login,
+    logout,
+    getDashboardPathForRole,
+  }
+}

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,215 @@
+<script setup>
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getDashboardPathForRole, login, useAuth } from '@/stores/auth'
+
+const router = useRouter()
+const route = useRoute()
+const { currentUser } = useAuth()
+
+const email = ref('')
+const password = ref('')
+const errorMessage = ref('')
+const isSubmitting = ref(false)
+
+if (currentUser.value) {
+  router.replace(getDashboardPathForRole(currentUser.value.role))
+}
+
+async function handleSubmit() {
+  errorMessage.value = ''
+
+  if (!email.value || !password.value) {
+    errorMessage.value = 'Harap isi email dan kata sandi.'
+    return
+  }
+
+  isSubmitting.value = true
+  try {
+    const user = login(email.value, password.value)
+    const redirectPath = route.query.redirect || getDashboardPathForRole(user.role)
+    router.replace(redirectPath)
+  } catch (error) {
+    errorMessage.value = error.message || 'Terjadi kesalahan saat login.'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="login-wrapper">
+    <div class="background-pattern"></div>
+    <div class="login-card">
+      <div class="card-glass">
+        <div class="card-header">
+          <h1>Selamat Datang Kembali</h1>
+          <p>Masuk untuk mengakses portal karyawan AMK.</p>
+        </div>
+
+        <form class="login-form" @submit.prevent="handleSubmit">
+          <label class="field">
+            <span>Email</span>
+            <input v-model="email" type="email" placeholder="nama@amk-portal.test" autocomplete="username" />
+          </label>
+
+          <label class="field">
+            <span>Kata Sandi</span>
+            <input
+              v-model="password"
+              type="password"
+              placeholder="Masukkan kata sandi"
+              autocomplete="current-password"
+            />
+          </label>
+
+          <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+          <button type="submit" :disabled="isSubmitting">
+            {{ isSubmitting ? 'Memproses...' : 'Masuk' }}
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.login-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.35), transparent 55%),
+    radial-gradient(circle at 85% 30%, rgba(139, 92, 246, 0.35), transparent 60%),
+    #05102a;
+  position: relative;
+  overflow: hidden;
+  padding: 1.5rem;
+}
+
+.background-pattern::before,
+.background-pattern::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.4;
+}
+
+.background-pattern::before {
+  width: 380px;
+  height: 380px;
+  background: rgba(59, 130, 246, 0.4);
+  top: -120px;
+  right: 12%;
+}
+
+.background-pattern::after {
+  width: 340px;
+  height: 340px;
+  background: rgba(34, 211, 238, 0.35);
+  bottom: -100px;
+  left: 10%;
+}
+
+.login-card {
+  position: relative;
+  max-width: 420px;
+  width: 100%;
+  z-index: 1;
+}
+
+.card-glass {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 32px;
+  padding: 2.8rem 2.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 30px 80px rgba(5, 16, 42, 0.35);
+  backdrop-filter: blur(22px);
+  color: #f5f7ff;
+}
+
+.card-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.card-header p {
+  margin: 0.75rem 0 2rem;
+  color: rgba(245, 247, 255, 0.75);
+  line-height: 1.6;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.field span {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field input {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  background: rgba(5, 16, 42, 0.4);
+  color: #f5f7ff;
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.25);
+}
+
+.error-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #fca5a5;
+}
+
+button[type='submit'] {
+  border: none;
+  border-radius: 16px;
+  padding: 0.95rem;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(139, 92, 246, 0.95));
+  color: #f5f7ff;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+button[type='submit']:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(59, 130, 246, 0.45);
+}
+
+button[type='submit']:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+@media (max-width: 540px) {
+  .card-glass {
+    padding: 2.2rem 1.8rem;
+  }
+
+  .card-header h1 {
+    font-size: 1.65rem;
+  }
+}
+</style>

--- a/src/views/admin/AdminDashboard.vue
+++ b/src/views/admin/AdminDashboard.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import IconHome from '@/components/icons/IconHome.vue'
+import IconUsers from '@/components/icons/IconUsers.vue'
+import IconDocument from '@/components/icons/IconDocument.vue'
+import { logout as performLogout, useAuth } from '@/stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const { currentUser } = useAuth()
+
+const menuItems = [
+  { label: 'Dashboard', to: { name: 'AdminHome' }, icon: IconHome },
+  { label: 'Pegawai', to: { name: 'AdminEmployees' }, icon: IconUsers },
+  { label: 'Slip Gaji', to: { name: 'AdminPayslips' }, icon: IconDocument },
+]
+
+const activeSectionTitle = computed(() => route.meta.sectionTitle || 'Dashboard')
+
+const userInfo = computed(() => ({
+  name: currentUser.value?.name ?? 'Admin',
+  role: currentUser.value?.role ?? 'admin',
+}))
+
+function handleLogout() {
+  performLogout()
+  router.replace({ name: 'Login' })
+}
+</script>
+
+<template>
+  <DashboardLayout :menu-items="menuItems" :page-title="activeSectionTitle" :user="userInfo" @logout="handleLogout">
+    <RouterView />
+  </DashboardLayout>
+</template>

--- a/src/views/admin/AdminEmployees.vue
+++ b/src/views/admin/AdminEmployees.vue
@@ -1,0 +1,195 @@
+<script setup>
+import { computed, ref } from 'vue'
+
+const searchTerm = ref('')
+
+const employees = [
+  { name: 'Aulia Rahma', position: 'Finance Specialist', status: 'Aktif', division: 'Keuangan' },
+  { name: 'Bagas Pratama', position: 'HR Generalist', status: 'Cuti', division: 'Human Capital' },
+  { name: 'Citra Widya', position: 'IT Support', status: 'Aktif', division: 'Teknologi' },
+  { name: 'Dimas Saputra', position: 'Data Analyst', status: 'Aktif', division: 'Business Intelligence' },
+  { name: 'Eka Laras', position: 'Marketing Officer', status: 'Aktif', division: 'Pemasaran' },
+]
+
+const filteredEmployees = computed(() => {
+  const keyword = searchTerm.value.trim().toLowerCase()
+  if (!keyword) {
+    return employees
+  }
+  return employees.filter((employee) =>
+    [employee.name, employee.position, employee.division]
+      .join(' ')
+      .toLowerCase()
+      .includes(keyword),
+  )
+})
+</script>
+
+<template>
+  <section class="employees">
+    <div class="toolbar glass-card">
+      <div>
+        <h2>Data Pegawai</h2>
+        <p class="subtitle">Gunakan pencarian untuk mempercepat pencarian pegawai.</p>
+      </div>
+      <label class="search-field">
+        <span>Cari pegawai</span>
+        <input v-model="searchTerm" type="search" placeholder="Ketik nama atau divisi" />
+      </label>
+    </div>
+
+    <div class="glass-card table-card">
+      <table>
+        <thead>
+          <tr>
+            <th>Nama</th>
+            <th>Posisi</th>
+            <th>Divisi</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="employee in filteredEmployees" :key="employee.name">
+            <td>
+              <p class="name">{{ employee.name }}</p>
+            </td>
+            <td>{{ employee.position }}</td>
+            <td>{{ employee.division }}</td>
+            <td>
+              <span class="status" :class="{ active: employee.status === 'Aktif' }">{{ employee.status }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.employees {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.6rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.toolbar h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #111e46;
+}
+
+.subtitle {
+  margin: 0.4rem 0 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.95rem;
+}
+
+.search-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.search-field span {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.search-field input {
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  padding: 0.8rem 1rem;
+  font-size: 0.95rem;
+  background: rgba(15, 23, 42, 0.04);
+  color: #0b1330;
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.search-field input:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.7);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.table-card {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 1rem 1rem 1rem 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(239, 68, 68, 0.12);
+  color: rgba(185, 28, 28, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status.active {
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .glass-card {
+    padding: 1.2rem;
+  }
+
+  table {
+    min-width: 480px;
+  }
+}
+</style>

--- a/src/views/admin/AdminOverview.vue
+++ b/src/views/admin/AdminOverview.vue
@@ -1,0 +1,755 @@
+<script setup>
+const summaryCards = [
+  {
+    title: 'Total Pegawai',
+    value: '128 Orang',
+    description: 'Naik 8% dari bulan lalu',
+    accent: 'primary',
+  },
+  {
+    title: 'Slip Gaji Terkirim',
+    value: '124 Slip',
+    description: '97% pegawai telah menerima',
+    accent: 'teal',
+  },
+  {
+    title: 'Pengajuan Cuti',
+    value: '18 Permintaan',
+    description: '5 menunggu persetujuan',
+    accent: 'purple',
+  },
+  {
+    title: 'Dokumen Pending',
+    value: '6 Dokumen',
+    description: 'Perlu ditindaklanjuti hari ini',
+    accent: 'amber',
+  },
+]
+
+const performanceBars = [
+  { label: 'Jan', payroll: 54, submissions: 46 },
+  { label: 'Feb', payroll: 68, submissions: 52 },
+  { label: 'Mar', payroll: 74, submissions: 60 },
+  { label: 'Apr', payroll: 79, submissions: 64 },
+  { label: 'Mei', payroll: 83, submissions: 68 },
+  { label: 'Jun', payroll: 88, submissions: 72 },
+  { label: 'Jul', payroll: 92, submissions: 78 },
+]
+
+const progressPrograms = [
+  { label: 'Onboarding', percentage: 95, detail: 'Batch baru selesai pelatihan' },
+  { label: 'Kepatuhan', percentage: 82, detail: 'Audit internal minggu ini' },
+  { label: 'Benefit', percentage: 78, detail: 'Pendaftaran BPJS gelombang 3' },
+  { label: 'Kinerja', percentage: 90, detail: 'Evaluasi Q2 diproses' },
+]
+
+const teamMembers = [
+  { name: 'Mary Johnson', role: 'HR Business Partner' },
+  { name: 'James Brown', role: 'Payroll Specialist' },
+  { name: 'Ayu Kartika', role: 'Recruitment Lead' },
+]
+
+const calendarEvents = [
+  { time: '09:30', title: 'Rapat slip gaji Juli', category: 'Penggajian' },
+  { time: '11:00', title: 'Kick-off pelatihan compliance', category: 'Pelatihan' },
+  { time: '15:00', title: 'Review KPI divisi Sales', category: 'Evaluasi' },
+]
+
+const upcomingItems = [
+  {
+    title: 'Pengumuman struktur organisasi',
+    description: 'Bagikan update struktur baru ke seluruh pegawai.',
+    date: '14 Juli 2023',
+  },
+  {
+    title: 'Tutup pengajuan cuti Q3',
+    description: 'Pastikan seluruh permintaan sudah disetujui.',
+    date: '18 Juli 2023',
+  },
+  {
+    title: 'Upload slip gaji Agustus',
+    description: 'Siapkan template dan jadwalkan distribusi.',
+    date: '1 Agustus 2023',
+  },
+]
+
+function getProgressStyle(percentage) {
+  const value = Math.max(0, Math.min(100, percentage))
+  return {
+    background: `conic-gradient(#3b82f6 ${value * 3.6}deg, rgba(148, 163, 184, 0.18) ${value * 3.6}deg)`
+  }
+}
+</script>
+
+<template>
+  <section class="overview-grid">
+    <div class="main-column">
+      <div class="welcome-grid">
+        <article class="glass-card welcome-card">
+          <div class="welcome-content">
+            <span class="tag">Dashboard HR</span>
+            <h2>Halo, Admin!</h2>
+            <p>
+              Ada beberapa tugas penting hari ini. Lanjutkan pengiriman slip gaji, periksa pengajuan cuti,
+              dan jaga agar tim tetap terinformasi.
+            </p>
+            <div class="welcome-actions">
+              <button type="button" class="primary-action">Lihat laporan</button>
+              <button type="button" class="ghost-action">Buat tugas</button>
+            </div>
+          </div>
+          <div class="welcome-illustration">
+            <div class="bubble bubble-lg"></div>
+            <div class="bubble bubble-md"></div>
+            <div class="desk"></div>
+            <div class="laptop"></div>
+            <div class="character"></div>
+          </div>
+        </article>
+
+        <div class="summary-stack">
+          <article
+            v-for="card in summaryCards"
+            :key="card.title"
+            class="glass-card summary-card"
+            :class="`summary-card--${card.accent}`"
+          >
+            <span class="summary-label">{{ card.title }}</span>
+            <strong class="summary-value">{{ card.value }}</strong>
+            <p class="summary-description">{{ card.description }}</p>
+          </article>
+        </div>
+      </div>
+
+      <div class="insight-grid">
+        <article class="glass-card performance-card">
+          <header>
+            <div>
+              <span class="tag">Performa</span>
+              <h3>Performa Penggajian</h3>
+            </div>
+            <button type="button" class="ghost-action">Unduh laporan</button>
+          </header>
+          <p class="subtitle">Progress pembayaran dan pengajuan selama tujuh bulan terakhir.</p>
+          <div class="chart-area">
+            <div v-for="bar in performanceBars" :key="bar.label" class="chart-bar">
+              <div class="bar payroll" :style="{ height: `${bar.payroll * 2}px` }"></div>
+              <div class="bar submission" :style="{ height: `${bar.submissions * 2}px` }"></div>
+              <span class="bar-label">{{ bar.label }}</span>
+            </div>
+          </div>
+          <footer class="chart-legend">
+            <span><span class="dot dot-primary"></span>Pembayaran selesai</span>
+            <span><span class="dot dot-secondary"></span>Pengajuan diterima</span>
+          </footer>
+        </article>
+
+        <article class="glass-card progress-card">
+          <header>
+            <div>
+              <span class="tag">Monitoring</span>
+              <h3>Program Berjalan</h3>
+            </div>
+            <button type="button" class="ghost-action">Lihat semua</button>
+          </header>
+          <div class="progress-grid">
+            <div v-for="program in progressPrograms" :key="program.label" class="progress-item">
+              <div class="progress-circle" :style="getProgressStyle(program.percentage)">
+                <span>{{ program.percentage }}%</span>
+              </div>
+              <div class="progress-info">
+                <h4>{{ program.label }}</h4>
+                <p>{{ program.detail }}</p>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <article class="glass-card team-card">
+        <header>
+          <div>
+            <span class="tag">Kolaborasi</span>
+            <h3>Tim HR Terhubung</h3>
+          </div>
+          <button type="button" class="ghost-action">Tambah anggota</button>
+        </header>
+        <ul class="team-list">
+          <li v-for="member in teamMembers" :key="member.name">
+            <div class="avatar">{{ member.name.charAt(0) }}</div>
+            <div>
+              <p class="team-name">{{ member.name }}</p>
+              <span class="team-role">{{ member.role }}</span>
+            </div>
+            <button type="button" class="link-button">Hubungi</button>
+          </li>
+        </ul>
+      </article>
+    </div>
+
+    <aside class="side-column">
+      <article class="glass-card calendar-card">
+        <header>
+          <div>
+            <span class="tag">Agenda</span>
+            <h3>Jadwal Hari Ini</h3>
+          </div>
+          <button type="button" class="ghost-action">Lihat kalender</button>
+        </header>
+        <ul class="calendar-list">
+          <li v-for="event in calendarEvents" :key="event.title">
+            <div class="event-time">{{ event.time }}</div>
+            <div class="event-info">
+              <p class="event-title">{{ event.title }}</p>
+              <span class="event-category">{{ event.category }}</span>
+            </div>
+          </li>
+        </ul>
+      </article>
+
+      <article class="glass-card upcoming-card">
+        <header>
+          <div>
+            <span class="tag">Upcoming</span>
+            <h3>Catatan Penting</h3>
+          </div>
+        </header>
+        <ul class="upcoming-list">
+          <li v-for="item in upcomingItems" :key="item.title">
+            <div>
+              <p class="upcoming-title">{{ item.title }}</p>
+              <p class="upcoming-description">{{ item.description }}</p>
+            </div>
+            <span class="upcoming-date">{{ item.date }}</span>
+          </li>
+        </ul>
+      </article>
+    </aside>
+  </section>
+</template>
+
+<style scoped>
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.4fr) minmax(260px, 0.9fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.main-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.welcome-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 28px;
+  padding: 1.8rem;
+  color: #0b1330;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 22px 55px rgba(4, 12, 32, 0.16);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+}
+
+.welcome-card {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.welcome-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.15), transparent 55%);
+  z-index: -1;
+}
+
+.welcome-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.welcome-content h2 {
+  margin: 0;
+  font-size: 1.85rem;
+  color: #111e46;
+}
+
+.welcome-content p {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.68);
+  line-height: 1.6;
+}
+
+.welcome-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary-action,
+.ghost-action {
+  border-radius: 14px;
+  padding: 0.65rem 1.3rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-action {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(99, 102, 241, 0.85));
+  color: #f5f7ff;
+  box-shadow: 0 15px 30px rgba(59, 130, 246, 0.35);
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(59, 130, 246, 0.45);
+}
+
+.ghost-action {
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.ghost-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(148, 163, 255, 0.25);
+}
+
+.welcome-illustration {
+  position: relative;
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bubble {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(59, 130, 246, 0.18);
+  filter: blur(0);
+}
+
+.bubble-lg {
+  width: 180px;
+  height: 180px;
+  top: 10%;
+  right: 14%;
+}
+
+.bubble-md {
+  width: 120px;
+  height: 120px;
+  bottom: 12%;
+  left: 18%;
+  background: rgba(129, 140, 248, 0.22);
+}
+
+.desk {
+  position: absolute;
+  bottom: 12%;
+  width: 180px;
+  height: 16px;
+  background: linear-gradient(90deg, rgba(148, 163, 255, 0.55), rgba(96, 165, 250, 0.55));
+  border-radius: 999px;
+}
+
+.laptop {
+  position: absolute;
+  bottom: 18%;
+  width: 120px;
+  height: 70px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.8), rgba(14, 165, 233, 0.7));
+  box-shadow: 0 12px 25px rgba(59, 130, 246, 0.35);
+}
+
+.character {
+  position: absolute;
+  bottom: 32%;
+  width: 70px;
+  height: 70px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(240, 171, 252, 0.75), rgba(14, 165, 233, 0.6));
+  box-shadow: 0 18px 25px rgba(37, 99, 235, 0.35);
+}
+
+.summary-stack {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.1rem;
+}
+
+.summary-card {
+  gap: 0.85rem;
+}
+
+.summary-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.65);
+}
+
+.summary-value {
+  font-size: 1.75rem;
+  color: #0f172a;
+}
+
+.summary-description {
+  margin: 0;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.summary-card--primary {
+  border-top: 4px solid rgba(59, 130, 246, 0.7);
+}
+
+.summary-card--teal {
+  border-top: 4px solid rgba(13, 148, 136, 0.65);
+}
+
+.summary-card--purple {
+  border-top: 4px solid rgba(168, 85, 247, 0.7);
+}
+
+.summary-card--amber {
+  border-top: 4px solid rgba(251, 191, 36, 0.7);
+}
+
+.insight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.performance-card header,
+.progress-card header,
+.team-card header,
+.calendar-card header,
+.upcoming-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.performance-card h3,
+.progress-card h3,
+.team-card h3,
+.calendar-card h3,
+.upcoming-card h3 {
+  margin: 0.35rem 0 0;
+  color: #111e46;
+  font-size: 1.15rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.chart-area {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  gap: 1rem;
+  align-items: end;
+  height: 220px;
+}
+
+.chart-bar {
+  display: grid;
+  grid-template-rows: 1fr 1fr auto;
+  gap: 0.35rem;
+  justify-items: center;
+}
+
+.bar {
+  width: 14px;
+  border-radius: 12px;
+}
+
+.bar.payroll {
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.9), rgba(14, 116, 144, 0.75));
+}
+
+.bar.submission {
+  background: linear-gradient(180deg, rgba(168, 85, 247, 0.85), rgba(99, 102, 241, 0.75));
+}
+
+.bar-label {
+  font-size: 0.75rem;
+  color: rgba(51, 65, 85, 0.65);
+}
+
+.chart-legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: rgba(51, 65, 85, 0.7);
+}
+
+.dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.45rem;
+}
+
+.dot-primary {
+  background: rgba(59, 130, 246, 0.9);
+}
+
+.dot-secondary {
+  background: rgba(168, 85, 247, 0.85);
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.progress-item {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.progress-circle {
+  width: 78px;
+  height: 78px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.progress-circle::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  background: #fff;
+}
+
+.progress-circle span {
+  position: relative;
+  font-weight: 700;
+  color: #111e46;
+}
+
+.progress-info h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.progress-info p {
+  margin: 0.35rem 0 0;
+  color: rgba(30, 41, 59, 0.6);
+  font-size: 0.9rem;
+}
+
+.team-list,
+.calendar-list,
+.upcoming-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.team-list li {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(129, 140, 248, 0.75));
+  display: grid;
+  place-items: center;
+  color: #f5f7ff;
+  font-weight: 700;
+}
+
+.team-name {
+  margin: 0;
+  font-weight: 600;
+  color: #111e46;
+}
+
+.team-role {
+  font-size: 0.85rem;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.link-button {
+  margin-left: auto;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(226, 232, 255, 0.9);
+  color: rgba(37, 99, 235, 0.9);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.calendar-list li {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.event-time {
+  font-weight: 700;
+  color: #111e46;
+}
+
+.event-title {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.event-category {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(51, 65, 85, 0.6);
+}
+
+.upcoming-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  padding-bottom: 0.9rem;
+}
+
+.upcoming-list li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.upcoming-title {
+  margin: 0;
+  font-weight: 600;
+  color: #111e46;
+}
+
+.upcoming-description {
+  margin: 0;
+  color: rgba(51, 65, 85, 0.65);
+  font-size: 0.9rem;
+}
+
+.upcoming-date {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(226, 232, 255, 0.9);
+  color: rgba(37, 99, 235, 0.85);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.side-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (max-width: 1200px) {
+  .overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .side-column {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .side-column > * {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 992px) {
+  .welcome-grid,
+  .insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .welcome-illustration {
+    min-height: 180px;
+  }
+
+  .chart-area {
+    height: 200px;
+  }
+}
+
+@media (max-width: 640px) {
+  .glass-card {
+    padding: 1.4rem;
+  }
+
+  .summary-value {
+    font-size: 1.5rem;
+  }
+
+  .chart-area {
+    gap: 0.75rem;
+  }
+
+  .chart-bar {
+    grid-template-rows: 1fr 1fr auto;
+  }
+
+  .progress-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .side-column {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/views/admin/AdminPayslips.vue
+++ b/src/views/admin/AdminPayslips.vue
@@ -1,0 +1,175 @@
+<script setup>
+const payslipSummary = [
+  { title: 'Slip gaji Januari', status: 'Terkirim', count: 125 },
+  { title: 'Slip gaji Februari', status: 'Proses', count: 12 },
+  { title: 'Slip gaji Maret', status: 'Dijadwalkan', count: 128 },
+]
+</script>
+
+<template>
+  <section class="payslips">
+    <div class="glass-card hero">
+      <div>
+        <h2>Status Distribusi Slip Gaji</h2>
+        <p class="subtitle">Ringkasan progres pengiriman slip gaji karyawan.</p>
+      </div>
+      <div class="stats">
+        <div class="stat">
+          <p class="label">Slip terkirim bulan ini</p>
+          <p class="value">124</p>
+        </div>
+        <div class="stat">
+          <p class="label">Menunggu validasi</p>
+          <p class="value">4</p>
+        </div>
+        <div class="stat">
+          <p class="label">Ditolak</p>
+          <p class="value">0</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="glass-card list">
+      <h3>Riwayat Pengiriman</h3>
+      <ul>
+        <li v-for="item in payslipSummary" :key="item.title">
+          <div>
+            <p class="title">{{ item.title }}</p>
+            <p class="status">Status: {{ item.status }}</p>
+          </div>
+          <span class="count">{{ item.count }} Pegawai</span>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.payslips {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.8rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.hero h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #111e46;
+}
+
+.subtitle {
+  margin: 0.5rem 0 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.95rem;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+}
+
+.stat {
+  background: rgba(59, 130, 246, 0.12);
+  border-radius: 18px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.stat:nth-child(2) {
+  background: rgba(234, 179, 8, 0.12);
+}
+
+.stat:nth-child(3) {
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.value {
+  margin: 0;
+  font-size: 1.7rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.list h3 {
+  margin: 0 0 1.25rem;
+  font-size: 1.1rem;
+  color: #111e46;
+}
+
+.list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.title {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.status {
+  margin: 0.4rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.count {
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+  border-radius: 14px;
+  padding: 0.45rem 1rem;
+}
+
+@media (max-width: 640px) {
+  .glass-card {
+    padding: 1.4rem;
+  }
+
+  .list li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .count {
+    align-self: flex-end;
+  }
+}
+</style>

--- a/src/views/officer/OfficerDashboard.vue
+++ b/src/views/officer/OfficerDashboard.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import IconHome from '@/components/icons/IconHome.vue'
+import { logout as performLogout, useAuth } from '@/stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const { currentUser } = useAuth()
+
+const menuItems = [
+  { label: 'Dashboard', to: { name: 'OfficerHome' }, icon: IconHome },
+]
+
+const activeSectionTitle = computed(() => route.meta.sectionTitle || 'Dashboard')
+
+const userInfo = computed(() => ({
+  name: currentUser.value?.name ?? 'Officer',
+  role: currentUser.value?.role ?? 'officer',
+}))
+
+function handleLogout() {
+  performLogout()
+  router.replace({ name: 'Login' })
+}
+</script>
+
+<template>
+  <DashboardLayout :menu-items="menuItems" :page-title="activeSectionTitle" :user="userInfo" @logout="handleLogout">
+    <RouterView />
+  </DashboardLayout>
+</template>

--- a/src/views/officer/OfficerPlaceholder.vue
+++ b/src/views/officer/OfficerPlaceholder.vue
@@ -1,0 +1,38 @@
+<template>
+  <section class="placeholder glass-card">
+    <h2>Dashboard Officer</h2>
+    <p>
+      Konten untuk officer akan segera tersedia. Sementara ini, Anda dapat menggunakan menu lain atau
+      kembali lagi nanti.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.8rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.placeholder h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #111e46;
+}
+
+.placeholder p {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.65);
+  line-height: 1.6;
+}
+</style>

--- a/src/views/pegawai/PegawaiBiodata.vue
+++ b/src/views/pegawai/PegawaiBiodata.vue
@@ -1,0 +1,137 @@
+<script setup>
+const biodata = {
+  name: 'Pegawai Andalan',
+  employeeId: 'EMP-2043',
+  position: 'Senior Finance Analyst',
+  division: 'Keuangan',
+  joinDate: '12 Januari 2019',
+  phone: '+62 812-3456-7890',
+  email: 'pegawai@amk-portal.test',
+  address: 'Jl. Melati No. 12, Jakarta Selatan',
+}
+</script>
+
+<template>
+  <section class="biodata">
+    <article class="glass-card profile">
+      <div class="avatar">{{ biodata.name.charAt(0) }}</div>
+      <div>
+        <h2>{{ biodata.name }}</h2>
+        <p class="id">ID Pegawai: {{ biodata.employeeId }}</p>
+      </div>
+    </article>
+
+    <div class="grid info-grid">
+      <article class="glass-card info">
+        <h3>Informasi Pekerjaan</h3>
+        <ul>
+          <li><span>Jabatan</span><strong>{{ biodata.position }}</strong></li>
+          <li><span>Divisi</span><strong>{{ biodata.division }}</strong></li>
+          <li><span>Tanggal Bergabung</span><strong>{{ biodata.joinDate }}</strong></li>
+        </ul>
+      </article>
+
+      <article class="glass-card info">
+        <h3>Kontak</h3>
+        <ul>
+          <li><span>Email</span><strong>{{ biodata.email }}</strong></li>
+          <li><span>No. Telepon</span><strong>{{ biodata.phone }}</strong></li>
+          <li><span>Alamat</span><strong>{{ biodata.address }}</strong></li>
+        </ul>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.biodata {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.6rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(139, 92, 246, 0.85));
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #f5f7ff;
+}
+
+.profile h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #111e46;
+}
+
+.id {
+  margin: 0.4rem 0 0;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.info h3 {
+  margin: 0 0 1.2rem;
+  font-size: 1.1rem;
+  color: #111e46;
+}
+
+.info ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.info li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.info span {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.info strong {
+  color: #0f172a;
+}
+
+@media (max-width: 640px) {
+  .profile {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .info li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/views/pegawai/PegawaiDashboard.vue
+++ b/src/views/pegawai/PegawaiDashboard.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import IconProfile from '@/components/icons/IconProfile.vue'
+import IconDocument from '@/components/icons/IconDocument.vue'
+import { logout as performLogout, useAuth } from '@/stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const { currentUser } = useAuth()
+
+const menuItems = [
+  { label: 'Biodata', to: { name: 'PegawaiBiodata' }, icon: IconProfile },
+  { label: 'Slip Gaji', to: { name: 'PegawaiPayslips' }, icon: IconDocument },
+]
+
+const activeSectionTitle = computed(() => route.meta.sectionTitle || 'Dashboard')
+
+const userInfo = computed(() => ({
+  name: currentUser.value?.name ?? 'Pegawai',
+  role: currentUser.value?.role ?? 'pegawai',
+}))
+
+function handleLogout() {
+  performLogout()
+  router.replace({ name: 'Login' })
+}
+</script>
+
+<template>
+  <DashboardLayout :menu-items="menuItems" :page-title="activeSectionTitle" :user="userInfo" @logout="handleLogout">
+    <RouterView />
+  </DashboardLayout>
+</template>

--- a/src/views/pegawai/PegawaiPayslips.vue
+++ b/src/views/pegawai/PegawaiPayslips.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { computed, ref } from 'vue'
+
+const years = [2024, 2023, 2022]
+const months = [
+  'Januari',
+  'Februari',
+  'Maret',
+  'April',
+  'Mei',
+  'Juni',
+  'Juli',
+  'Agustus',
+  'September',
+  'Oktober',
+  'November',
+  'Desember',
+]
+
+const selectedYear = ref(years[0])
+const selectedMonth = ref(months[new Date().getMonth()])
+
+const payslipData = {
+  2024: {
+    Januari: { gajiPokok: 'Rp8.500.000', bonus: 'Rp1.200.000', potongan: 'Rp250.000' },
+    Februari: { gajiPokok: 'Rp8.500.000', bonus: 'Rp900.000', potongan: 'Rp260.000' },
+    Maret: { gajiPokok: 'Rp8.500.000', bonus: 'Rp1.000.000', potongan: 'Rp255.000' },
+  },
+  2023: {
+    Desember: { gajiPokok: 'Rp8.200.000', bonus: 'Rp850.000', potongan: 'Rp240.000' },
+  },
+}
+
+const activePayslip = computed(() => {
+  const yearData = payslipData[selectedYear.value] || {}
+  return yearData[selectedMonth.value] || null
+})
+</script>
+
+<template>
+  <section class="payslip">
+    <article class="glass-card filter">
+      <div>
+        <h2>Slip Gaji</h2>
+        <p class="subtitle">Pilih periode untuk melihat detail slip gaji Anda.</p>
+      </div>
+      <div class="selectors">
+        <label>
+          <span>Tahun</span>
+          <select v-model="selectedYear">
+            <option v-for="year in years" :key="year" :value="year">{{ year }}</option>
+          </select>
+        </label>
+        <label>
+          <span>Bulan</span>
+          <select v-model="selectedMonth">
+            <option v-for="month in months" :key="month" :value="month">{{ month }}</option>
+          </select>
+        </label>
+      </div>
+    </article>
+
+    <article class="glass-card detail" v-if="activePayslip">
+      <h3>Detail Komponen</h3>
+      <ul>
+        <li><span>Gaji Pokok</span><strong>{{ activePayslip.gajiPokok }}</strong></li>
+        <li><span>Bonus</span><strong>{{ activePayslip.bonus }}</strong></li>
+        <li><span>Potongan</span><strong>{{ activePayslip.potongan }}</strong></li>
+      </ul>
+      <footer>
+        <p class="net-label">Take Home Pay</p>
+        <p class="net-amount">Rp9.450.000</p>
+      </footer>
+    </article>
+
+    <article class="glass-card empty" v-else>
+      <h3>Slip gaji belum tersedia</h3>
+      <p>Pilih periode lainnya untuk melihat riwayat slip gaji Anda.</p>
+    </article>
+  </section>
+</template>
+
+<style scoped>
+.payslip {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 1.6rem;
+  color: #0b1330;
+  box-shadow: 0 18px 40px rgba(4, 12, 32, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+}
+
+.filter h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #111e46;
+}
+
+.subtitle {
+  margin: 0.4rem 0 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.selectors {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 160px;
+}
+
+label span {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+select {
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.04);
+  font-size: 0.95rem;
+}
+
+.detail h3,
+.empty h3 {
+  margin: 0 0 1.2rem;
+  font-size: 1.1rem;
+  color: #111e46;
+}
+
+.detail ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.detail span {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.detail strong {
+  color: #0f172a;
+}
+
+footer {
+  margin-top: 1.5rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.net-label {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 600;
+}
+
+.net-amount {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.empty p {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 640px) {
+  .detail li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- restyle the dashboard chrome with a glassy sidebar, sticky topbar controls, and centered content container that echo the navy login palette
- rebuild the admin overview to mirror the provided inspiration with welcome hero, metric cards, charts, and agenda panels while keeping HR-centric data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6f8c8f28832189f79177b838df2c