### PR TITLE
Implement demo authentication and document dashboard credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup
 
-[VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+[VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and
+ disable Vetur).
 
 ## Recommended Browser Setup
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):
-  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) 
+  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
   - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
 - Firefox:
   - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
@@ -36,3 +37,12 @@ npm run dev
 ```sh
 npm run build
 ```
+
+## Akun Demo
+
+Gunakan akun berikut untuk mencoba tampilan dashboard:
+
+| Peran    | Email            | Kata Sandi  |
+|----------|------------------|-------------|
+| Admin    | admin@amk.com    | admin123    |
+| Pegawai  | pegawai@amk.com  | pegawai123  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "amk-portal3.0",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.22"
+        "vue": "^3.5.22",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -1434,6 +1435,12 @@
         "@vue/shared": "3.5.22"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/devtools-core": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.2.tgz",
@@ -2789,6 +2796,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.22"
+    "vue": "^3.5.22",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,47 +1,14 @@
-<script setup>
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
-</script>
-
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-    </div>
-  </header>
-
-  <main>
-    <TheWelcome />
-  </main>
+  <RouterView />
 </template>
 
-<style scoped>
-header {
-  line-height: 1.5;
-}
+<script setup>
+import { RouterView } from 'vue-router'
+</script>
 
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
+<style>
+:global(body) {
+  background: #f3f6ff;
+  color: #1a1f36;
 }
 </style>

--- a/src/assets/amk-logo.svg
+++ b/src/assets/amk-logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">AMK Portal Logo</title>
+  <desc id="desc">Stylized AMK lettering inside a rounded navy gradient badge.</desc>
+  <defs>
+    <linearGradient id="badgeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b2c59" />
+      <stop offset="100%" stop-color="#154e8a" />
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="110" height="110" rx="28" fill="url(#badgeGradient)" />
+  <path
+    d="M28 82V38h14l18 25 18-25h14v44h-12V57l-20 25-20-25v25H28Z"
+    fill="#ffffff"
+  />
+  <circle cx="60" cy="34" r="6" fill="#24a6ff" />
+</svg>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,35 +1,31 @@
 @import './base.css';
 
+:root {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #1b2142;
+  background-color: #f3f6ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f3f6ff;
+}
+
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  font-weight: normal;
+  width: 100%;
+  min-height: 100vh;
 }
 
-a,
-.green {
+a {
+  color: inherit;
   text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
-  transition: 0.4s;
-  padding: 3px;
 }
 
-@media (hover: hover) {
-  a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
-  }
+a:hover {
+  text-decoration: underline;
 }
 
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-  }
+button {
+  font-family: inherit;
 }

--- a/src/components/DashboardLayout.vue
+++ b/src/components/DashboardLayout.vue
@@ -1,0 +1,929 @@
+<template>
+  <div
+    class="dashboard"
+    :class="{ 'dashboard--sidebar-open': isSidebarOpen }"
+    :style="{ '--accent-color': accentColor }"
+  >
+    <aside class="sidebar">
+      <button type="button" class="sidebar__close" @click="closeSidebar" aria-label="Tutup menu">
+        <span />
+        <span />
+      </button>
+      <div class="sidebar__brand">
+        <div class="brand-icon">AMK</div>
+        <div class="brand-info">
+          <span class="brand-name">AMK Payroll</span>
+          <span class="brand-tag">Terpercaya sejak 2020</span>
+        </div>
+      </div>
+      <div class="sidebar__role">{{ role }}</div>
+      <nav class="sidebar__menu">
+        <button
+          v-for="(item, index) in menuItems"
+          :key="item.label"
+          type="button"
+          class="menu-item"
+          :class="{ active: index === 0 }"
+          @click="handleMenuClick"
+        >
+          <span class="menu-item__bullet" />
+          <div class="menu-item__text">
+            <span class="menu-item__label">{{ item.label }}</span>
+            <span v-if="item.helper" class="menu-item__helper">{{ item.helper }}</span>
+          </div>
+        </button>
+      </nav>
+      <div class="sidebar__footer">
+        <button type="button" class="sidebar__logout" @click="handleLogout">
+          <span class="sidebar__logout-icon">⎋</span>
+          <span>Keluar</span>
+        </button>
+        <div class="sidebar__support">
+          <p>Ada kendala?</p>
+          <a href="#">Hubungi tim kami</a>
+        </div>
+      </div>
+    </aside>
+
+    <div v-if="isSidebarOpen" class="sidebar-backdrop" @click="closeSidebar" />
+
+    <main class="dashboard__main">
+      <header class="dashboard__header">
+        <button type="button" class="sidebar-toggle" @click="toggleSidebar" aria-label="Buka menu">
+          <span />
+          <span />
+          <span />
+        </button>
+        <div>
+          <p class="dashboard__greeting">{{ greeting }}</p>
+          <h1>Selamat datang, {{ userName }}</h1>
+        </div>
+        <div class="dashboard__profile">
+          <div class="profile-name">
+            <span class="profile-label">Peran</span>
+            <span class="profile-value">{{ role }}</span>
+          </div>
+          <div class="profile-avatar">{{ initials }}</div>
+        </div>
+      </header>
+
+      <section class="cards-grid">
+        <article v-for="card in summaryCards" :key="card.title" class="summary-card">
+          <div class="summary-card__icon" :style="{ '--card-color': card.accent || accentColor }">
+            <span>{{ card.icon }}</span>
+          </div>
+          <div class="summary-card__body">
+            <p class="summary-card__title">{{ card.title }}</p>
+            <h2 class="summary-card__value">{{ card.value }}</h2>
+            <p class="summary-card__meta" v-if="card.meta">{{ card.meta }}</p>
+          </div>
+        </article>
+      </section>
+
+      <div class="content-grid">
+        <section class="recent-card">
+          <div class="card-header">
+            <div>
+              <h2>{{ recentTitle }}</h2>
+              <p>{{ recentSubtitle }}</p>
+            </div>
+            <button type="button">Lihat semua</button>
+          </div>
+          <ul class="recent-list">
+            <li v-for="item in recentItems" :key="item.id || item.name" class="recent-item">
+              <div class="recent-item__info">
+                <span class="recent-item__name">{{ item.name }}</span>
+                <span class="recent-item__desc">{{ item.description }}</span>
+              </div>
+              <div class="recent-item__meta">
+                <span class="recent-item__amount">{{ item.amount }}</span>
+                <span class="badge" :class="`badge--${item.status.tone}`">{{ item.status.label }}</span>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section class="stats-card">
+          <div class="card-header">
+            <div>
+              <h2>{{ stats.title }}</h2>
+              <p>{{ stats.subtitle }}</p>
+            </div>
+            <span class="stats-card__period">{{ stats.period }}</span>
+          </div>
+
+          <div class="stats-card__body">
+            <div class="stats-card__chart" :style="progressStyle">
+              <div class="stats-card__chart-inner">
+                <span class="chart-value">{{ stats.total }}</span>
+                <span class="chart-label">{{ stats.totalLabel }}</span>
+              </div>
+            </div>
+            <ul class="stats-card__list">
+              <li v-for="item in stats.items" :key="item.label">
+                <span>{{ item.label }}</span>
+                <strong>{{ item.value }}</strong>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="quickActions.length" class="quick-actions">
+            <h3>{{ quickActionsTitle }}</h3>
+            <div class="quick-actions__grid">
+              <article v-for="action in quickActions" :key="action.label" class="quick-action">
+                <h4>{{ action.label }}</h4>
+                <p>{{ action.description }}</p>
+              </article>
+            </div>
+          </div>
+
+          <footer class="stats-card__footer">
+            <span>{{ stats.footer }}</span>
+          </footer>
+        </section>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  userName: { type: String, required: true },
+  role: { type: String, required: true },
+  greeting: { type: String, default: 'Semoga harimu menyenangkan! 👋' },
+  menuItems: { type: Array, required: true },
+  summaryCards: { type: Array, required: true },
+  recentTitle: { type: String, default: 'Aktivitas terkini' },
+  recentSubtitle: { type: String, default: 'Pantau update terbaru secara real-time.' },
+  recentItems: { type: Array, default: () => [] },
+  stats: {
+    type: Object,
+    required: true,
+    default: () => ({})
+  },
+  quickActions: {
+    type: Array,
+    default: () => []
+  },
+  quickActionsTitle: { type: String, default: 'Aksi cepat' },
+  accentColor: { type: String, default: '#1f3c88' }
+})
+
+const emit = defineEmits(['logout'])
+
+const isSidebarOpen = ref(false)
+
+const initials = computed(() => {
+  return props.userName
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+})
+
+const toggleSidebar = () => {
+  isSidebarOpen.value = !isSidebarOpen.value
+}
+
+const closeSidebar = () => {
+  isSidebarOpen.value = false
+}
+
+const handleMenuClick = () => {
+  closeSidebar()
+}
+
+const handleLogout = () => {
+  emit('logout')
+  closeSidebar()
+}
+
+const handleResize = () => {
+  if (typeof window === 'undefined') return
+  if (window.innerWidth >= 820) {
+    isSidebarOpen.value = false
+  }
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') return
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('resize', handleResize)
+})
+
+const progressStyle = computed(() => {
+  const progress = Math.min(Math.max(props.stats.progress ?? 0.65, 0), 1)
+  const degrees = `${Math.round(progress * 360)}deg`
+  return {
+    '--progress-deg': degrees,
+    '--chart-color': props.stats.accent || props.accentColor
+  }
+})
+</script>
+
+<style scoped>
+.dashboard {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5f7ff 0%, #eef1ff 100%);
+  color: #1b2142;
+  position: relative;
+}
+
+.dashboard--sidebar-open {
+  overflow: hidden;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, #0f1c3f 0%, #122358 60%, #101a43 100%);
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  color: #ecf1ff;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform 0.3s ease;
+  position: relative;
+  z-index: 40;
+}
+
+.sidebar__close {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar__close span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 18px;
+  background: linear-gradient(135deg, var(--accent-color), rgba(99, 140, 255, 0.85));
+  color: #fff;
+}
+
+.brand-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-name {
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+
+.brand-tag {
+  font-size: 12px;
+  color: rgba(236, 241, 255, 0.65);
+}
+
+.sidebar__role {
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(15, 28, 63, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  width: fit-content;
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.02);
+  transition: background 0.2s ease, transform 0.2s ease;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.menu-item.active {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.menu-item__bullet {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.menu-item.active .menu-item__bullet {
+  background: #fff;
+}
+
+.menu-item__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.menu-item__label {
+  font-weight: 500;
+}
+
+.menu-item__helper {
+  font-size: 12px;
+  color: rgba(236, 241, 255, 0.6);
+}
+
+.sidebar__support {
+  margin-top: auto;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 16px;
+  border-radius: 16px;
+  font-size: 13px;
+}
+
+.sidebar__support a {
+  margin-top: 6px;
+  display: inline-block;
+  color: #9cb4ff;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar__logout {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(7, 15, 36, 0.45);
+  color: #ecf1ff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  align-self: flex-start;
+}
+
+.sidebar__logout:hover {
+  background: rgba(7, 15, 36, 0.65);
+  transform: translateY(-1px);
+}
+
+.sidebar__logout-icon {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.15);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 16, 35, 0.55);
+  z-index: 30;
+}
+
+.dashboard__main {
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  position: relative;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.dashboard__greeting {
+  font-size: 15px;
+  color: #6a7190;
+  margin-bottom: 4px;
+}
+
+.sidebar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  padding: 6px 4px;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.sidebar-toggle span {
+  display: block;
+  width: 24px;
+  height: 3px;
+  border-radius: 999px;
+  background: #1b2142;
+}
+
+.dashboard__header h1 {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.dashboard__profile {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.profile-name {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.profile-label {
+  font-size: 12px;
+  color: #7f87aa;
+  letter-spacing: 0.8px;
+}
+
+.profile-value {
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.profile-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent-color), rgba(95, 132, 250, 0.95));
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.summary-card {
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 24px;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  box-shadow:
+    0 18px 35px rgba(21, 36, 82, 0.06),
+    0 3px 8px rgba(27, 33, 66, 0.04);
+}
+
+.summary-card__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, var(--card-color), rgba(158, 184, 255, 0.9));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.summary-card__title {
+  font-size: 14px;
+  color: #767ca0;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.summary-card__value {
+  font-size: 26px;
+  font-weight: 600;
+  color: #161c3f;
+}
+
+.summary-card__meta {
+  font-size: 13px;
+  color: #6f7592;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.recent-card,
+.stats-card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px 26px;
+  box-shadow:
+    0 24px 45px rgba(21, 36, 82, 0.08),
+    0 4px 12px rgba(27, 33, 66, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-header h2 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.card-header p {
+  font-size: 13px;
+  color: #7f87aa;
+}
+
+.card-header button {
+  border: none;
+  background: rgba(31, 60, 136, 0.08);
+  color: var(--accent-color);
+  font-weight: 600;
+  padding: 10px 16px;
+  border-radius: 14px;
+  cursor: pointer;
+}
+
+.recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.recent-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed rgba(23, 31, 74, 0.1);
+}
+
+.recent-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.recent-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.recent-item__name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.recent-item__desc {
+  font-size: 13px;
+  color: #8087a3;
+}
+
+.recent-item__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.recent-item__amount {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge--success {
+  background: rgba(54, 211, 153, 0.15);
+  color: #1d9c6c;
+}
+
+.badge--warning {
+  background: rgba(255, 193, 7, 0.18);
+  color: #b88a00;
+}
+
+.badge--info {
+  background: rgba(78, 125, 255, 0.18);
+  color: #335ed7;
+}
+
+.badge--neutral {
+  background: rgba(127, 135, 170, 0.15);
+  color: #6d7394;
+}
+
+.stats-card__period {
+  font-size: 13px;
+  color: #7f87aa;
+}
+
+.stats-card__body {
+  display: flex;
+  gap: 24px;
+}
+
+.stats-card__chart {
+  --progress-deg: 240deg;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: conic-gradient(var(--chart-color) 0 var(--progress-deg), rgba(240, 243, 255, 0.8) var(--progress-deg) 360deg);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.stats-card__chart-inner {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  box-shadow: inset 0 2px 6px rgba(31, 60, 136, 0.08);
+}
+
+.chart-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.chart-label {
+  font-size: 12px;
+  color: #7f87aa;
+  text-align: center;
+}
+
+.stats-card__list {
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stats-card__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.stats-card__list strong {
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quick-actions h3 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.quick-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.quick-action {
+  background: rgba(31, 60, 136, 0.06);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quick-action h4 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.quick-action p {
+  font-size: 12px;
+  color: #6b7395;
+}
+
+.stats-card__footer {
+  font-size: 12px;
+  color: #8b92b4;
+  text-align: right;
+}
+
+@media (max-width: 1080px) {
+  .dashboard {
+    grid-template-columns: 240px 1fr;
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-card__body {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .stats-card__list {
+    width: 100%;
+  }
+}
+
+@media (max-width: 820px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+    position: relative;
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(78vw, 320px);
+    max-width: 340px;
+    height: 100vh;
+    transform: translateX(-100%);
+    box-shadow: 18px 0 35px rgba(12, 18, 38, 0.35);
+    padding: 28px 24px 32px;
+    gap: 28px;
+    border-right: none;
+  }
+
+  .dashboard--sidebar-open .sidebar {
+    transform: translateX(0);
+  }
+
+  .sidebar__close {
+    display: inline-flex;
+  }
+
+  .sidebar__footer {
+    gap: 12px;
+  }
+
+  .sidebar__support {
+    background: rgba(255, 255, 255, 0.04);
+    padding: 14px;
+  }
+
+  .dashboard__main {
+    padding: 28px 20px 36px;
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 18px;
+    position: relative;
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 640px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__header h1 {
+    font-size: 24px;
+  }
+
+  .profile-avatar {
+    width: 42px;
+    height: 42px;
+  }
+
+  .recent-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .recent-item__meta {
+    align-items: center;
+    flex-direction: row;
+    gap: 12px;
+  }
+
+  .stats-card__body {
+    align-items: stretch;
+  }
+
+  .quick-actions__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .dashboard__main {
+    padding: 24px 16px 32px;
+  }
+
+  .summary-card {
+    padding: 20px;
+    border-radius: 18px;
+  }
+
+  .recent-card,
+  .stats-card {
+    padding: 20px;
+    border-radius: 20px;
+  }
+
+  .card-header h2 {
+    font-size: 18px;
+  }
+
+  .stats-card__chart {
+    width: 180px;
+    height: 180px;
+  }
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,8 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.use(router)
+app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,51 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import LoginView from '../views/LoginView.vue'
+import AdminDashboard from '../views/AdminDashboard.vue'
+import EmployeeDashboard from '../views/EmployeeDashboard.vue'
+import { ROLE_ROUTES, getStoredUser } from '../utils/auth'
+
+const routes = [
+  { path: '/', redirect: '/login' },
+  { path: '/login', name: 'login', component: LoginView },
+  {
+    path: '/admin',
+    name: 'admin-dashboard',
+    component: AdminDashboard,
+    meta: { requiresAuth: true, role: 'admin' }
+  },
+  {
+    path: '/pegawai',
+    name: 'employee-dashboard',
+    component: EmployeeDashboard,
+    meta: { requiresAuth: true, role: 'pegawai' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+router.beforeEach((to, from, next) => {
+  const user = getStoredUser()
+
+  if (to.meta.requiresAuth && !user) {
+    next({ name: 'login', query: { redirect: to.fullPath } })
+    return
+  }
+
+  if (to.meta.role && user && to.meta.role !== user.role) {
+    next({ path: ROLE_ROUTES[user.role] || '/login' })
+    return
+  }
+
+  if (to.name === 'login' && user) {
+    next({ path: ROLE_ROUTES[user.role] || '/admin' })
+    return
+  }
+
+  next()
+})
+
+export default router

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,29 @@
+const STORAGE_KEY = 'amk-portal-auth'
+
+export const ROLE_ROUTES = {
+  admin: '/admin',
+  pegawai: '/pegawai'
+}
+
+export function storeUserSession(user) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+}
+
+export function getStoredUser() {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    console.warn('Gagal mengurai data sesi pengguna', error)
+    window.localStorage.removeItem(STORAGE_KEY)
+    return null
+  }
+}
+
+export function clearUserSession() {
+  if (typeof window === 'undefined') return
+  window.localStorage.removeItem(STORAGE_KEY)
+}

--- a/src/views/AdminDashboard.vue
+++ b/src/views/AdminDashboard.vue
@@ -1,0 +1,123 @@
+<template>
+  <DashboardLayout
+    :user-name="userName"
+    role="Administrator"
+    :menu-items="menuItems"
+    :summary-cards="summaryCards"
+    recent-title="Aktivitas payroll"
+    recent-subtitle="Aktivitas terbaru tim HR & payroll."
+    :recent-items="recentItems"
+    :stats="stats"
+    :quick-actions="quickActions"
+    quick-actions-title="Aksi cepat untuk admin"
+    accent-color="#1f3c88"
+    greeting="Semangat mengelola tim hari ini!"
+    @logout="handleLogout"
+  />
+</template>
+
+<script setup>
+import DashboardLayout from '../components/DashboardLayout.vue'
+import { useRouter } from 'vue-router'
+import { clearUserSession, getStoredUser } from '../utils/auth'
+
+const menuItems = [
+  { label: 'Beranda', helper: 'Ringkasan hari ini' },
+  { label: 'Pegawai', helper: 'Kelola data karyawan' },
+  { label: 'Slip Gaji', helper: 'Kirim & arsipkan slip' }
+]
+
+const router = useRouter()
+
+const sessionUser = getStoredUser()
+
+if (!sessionUser || sessionUser.role !== 'admin') {
+  router.replace({ name: 'login' })
+}
+
+const userName = sessionUser?.name ?? 'Naufal Pratama'
+
+const handleLogout = () => {
+  clearUserSession()
+  router.push('/login')
+}
+
+const summaryCards = [
+  {
+    title: 'Total Pegawai',
+    value: '128 Pegawai',
+    meta: '+5 pegawai baru bulan ini',
+    icon: '👥',
+    accent: '#4e7dff'
+  },
+  {
+    title: 'Slip gaji terkirim',
+    value: '245 Slip',
+    meta: '98% dari target bulan ini',
+    icon: '💼',
+    accent: '#5bc4bf'
+  },
+  {
+    title: 'Pengajuan pending',
+    value: '12 Tugas',
+    meta: 'Perlu ditindak lanjuti',
+    icon: '⏳',
+    accent: '#ffba5a'
+  }
+]
+
+const recentItems = [
+  {
+    id: 1,
+    name: 'Distribusi Slip April 2024',
+    description: 'Mengirimkan slip ke seluruh karyawan',
+    amount: 'Selesai',
+    status: { label: 'Terkirim', tone: 'success' }
+  },
+  {
+    id: 2,
+    name: 'Update data pegawai - Divisi Sales',
+    description: '3 pegawai baru ditambahkan',
+    amount: '+3 data',
+    status: { label: 'Diproses', tone: 'info' }
+  },
+  {
+    id: 3,
+    name: 'Reminder slip gaji kontrak',
+    description: '15 pegawai kontrak butuh follow-up',
+    amount: '15 pegawai',
+    status: { label: 'Perlu tindakan', tone: 'warning' }
+  }
+]
+
+const stats = {
+  title: 'Statistik penggajian',
+  subtitle: 'Rekap payroll bulan ini',
+  period: 'April 2024',
+  total: '98%',
+  totalLabel: 'Slip sudah terkirim',
+  progress: 0.82,
+  accent: '#4e7dff',
+  items: [
+    { label: 'Pegawai aktif', value: '128' },
+    { label: 'Slip menunggu', value: '4' },
+    { label: 'Slip bermasalah', value: '1' }
+  ],
+  footer: 'Diperbarui 10 menit yang lalu'
+}
+
+const quickActions = [
+  {
+    label: 'Kirim slip gaji massal',
+    description: 'Kirim slip gaji ke seluruh karyawan dalam satu klik.'
+  },
+  {
+    label: 'Tambah pegawai baru',
+    description: 'Lengkapi data onboarding untuk karyawan baru.'
+  },
+  {
+    label: 'Unduh laporan',
+    description: 'Rekap penggajian bulanan siap diunduh.'
+  }
+]
+</script>

--- a/src/views/EmployeeDashboard.vue
+++ b/src/views/EmployeeDashboard.vue
@@ -1,0 +1,119 @@
+<template>
+  <DashboardLayout
+    :user-name="userName"
+    role="Pegawai"
+    :menu-items="menuItems"
+    :summary-cards="summaryCards"
+    recent-title="Slip gaji terbaru"
+    recent-subtitle="Riwayat slip gaji Anda selama 6 bulan terakhir."
+    :recent-items="recentItems"
+    :stats="stats"
+    :quick-actions="quickActions"
+    quick-actions-title="Butuh melakukan sesuatu?"
+    accent-color="#1f3c88"
+    greeting="Hai, berikut ringkasan gaji Anda!"
+    @logout="handleLogout"
+  />
+</template>
+
+<script setup>
+import DashboardLayout from '../components/DashboardLayout.vue'
+import { useRouter } from 'vue-router'
+import { clearUserSession, getStoredUser } from '../utils/auth'
+
+const menuItems = [
+  { label: 'Beranda', helper: 'Ringkasan pribadi' },
+  { label: 'Biodata', helper: 'Lengkapi informasi Anda' },
+  { label: 'Slip Gaji', helper: 'Lihat riwayat slip' }
+]
+
+const summaryCards = [
+  {
+    title: 'Total slip diterima',
+    value: '36 Slip',
+    meta: 'Aktif sejak Jan 2021',
+    icon: '📄',
+    accent: '#4e7dff'
+  },
+  {
+    title: 'Gaji terakhir',
+    value: 'Rp 12.500.000',
+    meta: 'Ditransfer 25 Maret 2024',
+    icon: '💳',
+    accent: '#5bc4bf'
+  },
+  {
+    title: 'Tunjangan tersisa',
+    value: 'Rp 1.250.000',
+    meta: 'Klaim sebelum 30 April',
+    icon: '🎁',
+    accent: '#ffba5a'
+  }
+]
+
+const recentItems = [
+  {
+    id: 1,
+    name: 'Slip Maret 2024',
+    description: 'Gaji pokok + lembur',
+    amount: 'Rp 12.500.000',
+    status: { label: 'Tersedia', tone: 'success' }
+  },
+  {
+    id: 2,
+    name: 'Slip Februari 2024',
+    description: 'Gaji pokok',
+    amount: 'Rp 12.000.000',
+    status: { label: 'Diarsipkan', tone: 'neutral' }
+  },
+  {
+    id: 3,
+    name: 'Slip Januari 2024',
+    description: 'Gaji pokok + bonus tahunan',
+    amount: 'Rp 18.500.000',
+    status: { label: 'Diarsipkan', tone: 'neutral' }
+  }
+]
+
+const stats = {
+  title: 'Ringkasan pendapatan',
+  subtitle: 'Total pendapatan per tahun',
+  period: 'Tahun 2024',
+  total: '27%',
+  totalLabel: 'Peningkatan dari tahun lalu',
+  progress: 0.27,
+  accent: '#4e7dff',
+  items: [
+    { label: 'Total pendapatan 2024', value: 'Rp 37.000.000' },
+    { label: 'Lembur diterima', value: 'Rp 3.200.000' },
+    { label: 'Bonus tahunan', value: 'Rp 6.500.000' }
+  ],
+  footer: 'Data diperbarui otomatis setiap bulan'
+}
+
+const quickActions = [
+  {
+    label: 'Perbarui biodata',
+    description: 'Perbarui alamat, rekening, dan kontak darurat.'
+  },
+  {
+    label: 'Unduh slip gaji',
+    description: 'Pilih bulan dan unduh slip gaji Anda kapan saja.'
+  }
+]
+
+const router = useRouter()
+
+const sessionUser = getStoredUser()
+
+if (!sessionUser || sessionUser.role !== 'pegawai') {
+  router.replace({ name: 'login' })
+}
+
+const userName = sessionUser?.name ?? 'Anisa Putri'
+
+const handleLogout = () => {
+  clearUserSession()
+  router.push('/login')
+}
+</script>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,348 @@
+<template>
+  <div class="login-page">
+    <div class="login-card">
+      <div class="login-card__info">
+        <div class="brand">
+          <span class="brand__symbol">AMK</span>
+          <span class="brand__title">Portal Penggajian</span>
+        </div>
+        <h1>Masuk ke akun Anda</h1>
+        <p>Kelola slip gaji dan informasi pegawai dalam satu tempat yang rapi.</p>
+        <form class="login-form" @submit.prevent="handleLogin">
+          <label>
+            Email
+            <input
+              v-model.trim="email"
+              type="email"
+              placeholder="nama@perusahaan.com"
+              autocomplete="email"
+              required
+            />
+          </label>
+          <label>
+            Kata sandi
+            <input
+              v-model="password"
+              :type="isPasswordVisible ? 'text' : 'password'"
+              placeholder="Masukkan kata sandi"
+              autocomplete="current-password"
+              required
+            />
+          </label>
+          <div class="form-footer">
+            <label class="remember">
+              <input type="checkbox" v-model="rememberMe" />
+              Ingat saya
+            </label>
+            <button type="button" class="toggle-password" @click="togglePasswordVisibility">
+              {{ isPasswordVisible ? 'Sembunyikan' : 'Tampilkan' }}
+            </button>
+          </div>
+          <p v-if="errorMessage" class="form-error">{{ errorMessage }}</p>
+          <button type="submit">Masuk</button>
+        </form>
+        <div class="login-links">
+          <span>Belum punya akun?</span>
+          <a href="#">Hubungi administrator</a>
+        </div>
+      </div>
+      <div class="login-card__preview">
+        <div class="preview-overlay">
+          <h2>Ringkas &amp; modern</h2>
+          <p>Desain dashboard yang elegan mempermudah Anda memantau performa perusahaan.</p>
+          <div class="login-hint">
+            <p>Coba masuk menggunakan akun demo:</p>
+            <ul>
+              <li><strong>Admin:</strong> admin@amk.com / admin123</li>
+              <li><strong>Pegawai:</strong> pegawai@amk.com / pegawai123</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { ROLE_ROUTES, storeUserSession } from '../utils/auth'
+
+const router = useRouter()
+const route = useRoute()
+
+const email = ref('')
+const password = ref('')
+const rememberMe = ref(false)
+const errorMessage = ref('')
+const isPasswordVisible = ref(false)
+
+const dummyAccounts = [
+  {
+    email: 'admin@amk.com',
+    password: 'admin123',
+    role: 'admin',
+    name: 'Naufal Pratama',
+    position: 'Administrator HR'
+  },
+  {
+    email: 'pegawai@amk.com',
+    password: 'pegawai123',
+    role: 'pegawai',
+    name: 'Raisa Dewi',
+    position: 'Spesialis Marketing'
+  }
+]
+
+const togglePasswordVisibility = () => {
+  isPasswordVisible.value = !isPasswordVisible.value
+}
+
+const handleLogin = () => {
+  const account = dummyAccounts.find(
+    (item) => item.email.toLowerCase() === email.value.toLowerCase() && item.password === password.value
+  )
+
+  if (!account) {
+    errorMessage.value = 'Email atau kata sandi salah. Silakan coba lagi.'
+    return
+  }
+
+  storeUserSession({
+    email: account.email,
+    role: account.role,
+    name: account.name,
+    position: account.position,
+    remember: rememberMe.value
+  })
+
+  errorMessage.value = ''
+  const redirectTarget = route.query.redirect
+  const targetPath =
+    typeof redirectTarget === 'string' && redirectTarget.length
+      ? redirectTarget
+      : ROLE_ROUTES[account.role]
+
+  router.push(targetPath)
+}
+</script>
+
+<style scoped>
+.login-page {
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1f2d66, #0f1434 70%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+}
+
+.login-card {
+  width: min(960px, 100%);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 40px 80px rgba(7, 12, 32, 0.45);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  overflow: hidden;
+}
+
+.login-card__info {
+  padding: 48px;
+  background: rgba(11, 20, 60, 0.85);
+  color: #f4f7ff;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.brand__symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1f3c88, #2f63ff);
+  color: #fff;
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.brand__title {
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.login-card h1 {
+  font-size: 32px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.login-card p {
+  color: rgba(240, 243, 255, 0.7);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.login-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  color: rgba(240, 243, 255, 0.85);
+}
+
+.login-form input {
+  background: rgba(10, 15, 42, 0.9);
+  border: 1px solid rgba(77, 95, 171, 0.6);
+  border-radius: 14px;
+  padding: 14px 16px;
+  color: #f4f7ff;
+  font-size: 15px;
+}
+
+.login-form input:focus {
+  outline: none;
+  border-color: #5d8dff;
+  box-shadow: 0 0 0 3px rgba(93, 141, 255, 0.25);
+}
+
+.form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: rgba(240, 243, 255, 0.7);
+}
+
+.remember {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toggle-password {
+  background: none;
+  border: none;
+  color: #7ea2ff;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+}
+
+.form-footer a,
+.login-links a {
+  color: #7ea2ff;
+}
+
+.form-error {
+  background: rgba(255, 90, 90, 0.12);
+  border: 1px solid rgba(255, 138, 138, 0.4);
+  color: #ffd6d6;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-size: 13px;
+}
+
+.login-form button[type='submit'] {
+  margin-top: 8px;
+  background: linear-gradient(135deg, #3558ff, #1f3c88);
+  color: #fff;
+  border: none;
+  border-radius: 16px;
+  padding: 16px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form button[type='submit']:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(12, 21, 59, 0.35);
+}
+
+.login-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: rgba(240, 243, 255, 0.75);
+}
+
+.login-card__preview {
+  position: relative;
+  background: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=900&q=80')
+    center/cover;
+  min-height: 320px;
+}
+
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(9, 15, 43, 0.65), rgba(15, 24, 59, 0.95));
+  color: #f4f7ff;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 48px;
+  gap: 16px;
+}
+
+.login-hint {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+  font-size: 13px;
+  color: rgba(244, 247, 255, 0.9);
+}
+
+.login-hint ul {
+  margin-top: 8px;
+  display: grid;
+  gap: 6px;
+  list-style: none;
+  padding: 0;
+}
+
+.login-hint strong {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .login-card {
+    border-radius: 24px;
+  }
+
+  .login-card__info,
+  .preview-overlay {
+    padding: 32px 24px;
+  }
+}
+
+@media (max-width: 520px) {
+  .login-card {
+    grid-template-columns: 1fr;
+  }
+
+  .login-card__preview {
+    order: -1;
+  }
+}
+</style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,71 +1,120 @@
 <template>
-  <div class="login-page">
-    <div class="login-card">
-      <div class="login-card__info">
-        <div class="brand">
-          <span class="brand__symbol">AMK</span>
-          <span class="brand__title">Portal Penggajian</span>
-        </div>
-        <h1>Masuk ke akun Anda</h1>
-        <p>Kelola slip gaji dan informasi pegawai dalam satu tempat yang rapi.</p>
-        <form class="login-form" @submit.prevent="handleLogin">
-          <label>
-            Email
-            <input
-              v-model.trim="email"
-              type="email"
-              placeholder="nama@perusahaan.com"
-              autocomplete="email"
-              required
-            />
-          </label>
-          <label>
-            Kata sandi
+  <div class="page">
+    <div class="background-gradient"></div>
+    <div class="background-accent background-accent--one"></div>
+    <div class="background-accent background-accent--two"></div>
+
+    <section class="login-card" aria-labelledby="login-title">
+      <header class="login-card__header">
+        <img src="@/assets/amk-logo.svg" alt="Logo AMK" class="login-card__logo" />
+        <h1 id="login-title" style="color: #1E1E54;">AMK Portal</h1>
+        <p class="login-card__subtitle">Cek biodata dan slip gaji Anda dengan akses jauh lebih mudah</p>
+      </header>
+
+      <form class="login-form" @submit.prevent="handleSubmit">
+        <label class="login-form__field">
+          <span style="color: #1E1E54;  font-weight: bold;">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            placeholder="nama@email.com"
+            autocomplete="email"
+            required
+          />
+        </label>
+
+        <label class="login-form__field">
+          <span style="color: #1E1E54; font-weight: bold;">Kata Sandi</span>
+          <div class="password-input">
             <input
               v-model="password"
-              :type="isPasswordVisible ? 'text' : 'password'"
+              :type="showPassword ? 'text' : 'password'"
               placeholder="Masukkan kata sandi"
               autocomplete="current-password"
               required
             />
-          </label>
-          <div class="form-footer">
-            <label class="remember">
-              <input type="checkbox" v-model="rememberMe" />
-              Ingat saya
-            </label>
-            <button type="button" class="toggle-password" @click="togglePasswordVisibility">
-              {{ isPasswordVisible ? 'Sembunyikan' : 'Tampilkan' }}
+            <button
+              type="button"
+              class="password-input__toggle"
+              :aria-label="showPassword ? 'Sembunyikan kata sandi' : 'Tampilkan kata sandi'"
+              :title="showPassword ? 'Sembunyikan kata sandi' : 'Tampilkan kata sandi'"
+              :aria-pressed="showPassword ? 'true' : 'false'"
+              @click="togglePassword"
+            >
+              <!-- Eye (show) -->
+              <svg
+                v-if="!showPassword"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+
+              <!-- Eye off (hide) -->
+              <svg
+                v-else
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.5 21.5 0 0 1 5.06-5.94" />
+                <path d="M1 1l22 22" />
+                <path d="M9.88 9.88A3 3 0 0 0 12 15a3 3 0 0 0 2.12-.88" />
+                <path d="M14.12 14.12 9.88 9.88" />
+                <path d="M22.94 12a21.5 21.5 0 0 0-5.06-5.94" />
+              </svg>
             </button>
           </div>
-          <p v-if="errorMessage" class="form-error">{{ errorMessage }}</p>
-          <button type="submit">Masuk</button>
-        </form>
-        <div class="login-links">
-          <span>Belum punya akun?</span>
-          <a href="#">Hubungi administrator</a>
+        </label>
+
+        <div class="login-form__actions">
+          <label class="remember">
+            <input v-model="remember" type="checkbox" />
+            <span>Ingat saya</span>
+          </label>
+          <a href="#" class="link">Lupa kata sandi?</a>
         </div>
-      </div>
-      <div class="login-card__preview">
-        <div class="preview-overlay">
-          <h2>Ringkas &amp; modern</h2>
-          <p>Desain dashboard yang elegan mempermudah Anda memantau performa perusahaan.</p>
-          <div class="login-hint">
-            <p>Coba masuk menggunakan akun demo:</p>
-            <ul>
-              <li><strong>Admin:</strong> admin@amk.com / admin123</li>
-              <li><strong>Pegawai:</strong> pegawai@amk.com / pegawai123</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
+
+        <p v-if="errorMessage" class="login-form__error">{{ errorMessage }}</p>
+
+        <button type="submit" class="button button--primary" :disabled="isSubmitting">
+          {{ isSubmitting ? 'Memproses…' : 'Masuk' }}
+        </button>
+
+        <p class="login-form__help" style="font-weight: bold;">
+          Butuh bantuan?
+          <a
+            href="https://api.whatsapp.com/send/?phone=%2B6285173088119&text&type=phone_number&app_absent=0"
+            style="color:blue; font-style:italic; font-weight:bold;"
+            target="_blank"
+            rel="noopener"
+          >Klik Disini</a>
+        </p>
+      </form>
+    </section>
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+
 import { ROLE_ROUTES, storeUserSession } from '../utils/auth'
 
 const router = useRouter()
@@ -73,9 +122,10 @@ const route = useRoute()
 
 const email = ref('')
 const password = ref('')
-const rememberMe = ref(false)
+const remember = ref(false)
+const isSubmitting = ref(false)
+const showPassword = ref(false)
 const errorMessage = ref('')
-const isPasswordVisible = ref(false)
 
 const dummyAccounts = [
   {
@@ -94,255 +144,368 @@ const dummyAccounts = [
   }
 ]
 
-const togglePasswordVisibility = () => {
-  isPasswordVisible.value = !isPasswordVisible.value
+const togglePassword = () => {
+  showPassword.value = !showPassword.value
 }
 
-const handleLogin = () => {
-  const account = dummyAccounts.find(
-    (item) => item.email.toLowerCase() === email.value.toLowerCase() && item.password === password.value
-  )
+const handleSubmit = async () => {
+  if (isSubmitting.value) return
 
-  if (!account) {
-    errorMessage.value = 'Email atau kata sandi salah. Silakan coba lagi.'
-    return
-  }
-
-  storeUserSession({
-    email: account.email,
-    role: account.role,
-    name: account.name,
-    position: account.position,
-    remember: rememberMe.value
-  })
-
+  isSubmitting.value = true
   errorMessage.value = ''
-  const redirectTarget = route.query.redirect
-  const targetPath =
-    typeof redirectTarget === 'string' && redirectTarget.length
-      ? redirectTarget
-      : ROLE_ROUTES[account.role]
 
-  router.push(targetPath)
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const account = dummyAccounts.find(
+      (item) => item.email.toLowerCase() === email.value.toLowerCase() && item.password === password.value
+    )
+
+    if (!account) {
+      errorMessage.value = 'Email atau kata sandi salah. Silakan coba lagi.'
+      return
+    }
+
+    storeUserSession({
+      email: account.email,
+      role: account.role,
+      name: account.name,
+      position: account.position,
+      remember: remember.value
+    })
+
+    const redirectTarget = route.query.redirect
+    const targetPath =
+      typeof redirectTarget === 'string' && redirectTarget.length
+        ? redirectTarget
+        : ROLE_ROUTES[account.role] || '/login'
+
+    await router.push(targetPath)
+  } finally {
+    isSubmitting.value = false
+  }
 }
 </script>
 
 <style scoped>
-.login-page {
+.page {
+  position: relative;
   min-height: 100vh;
-  background: radial-gradient(circle at top left, #1f2d66, #0f1434 70%);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px 16px;
-}
-
-.login-card {
-  width: min(960px, 100%);
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 32px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 40px 80px rgba(7, 12, 32, 0.45);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: clamp(1.5rem, 3vw, 3rem);
+  background: linear-gradient(160deg, #071f3d 0%, #0b2c59 45%, #154e8a 100%);
   overflow: hidden;
 }
 
-.login-card__info {
-  padding: 48px;
-  background: rgba(11, 20, 60, 0.85);
-  color: #f4f7ff;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+.background-gradient {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.1), transparent 55%),
+    radial-gradient(circle at bottom, rgba(21, 78, 138, 0.35), transparent 60%);
+  opacity: 0.85;
 }
 
-.brand {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.background-accent {
+  position: absolute;
+  width: clamp(180px, 32vw, 340px);
+  height: clamp(180px, 32vw, 340px);
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.6;
+  z-index: 1;
 }
 
-.brand__symbol {
-  display: inline-flex;
+.background-accent--one {
+  top: clamp(-80px, -6vw, -40px);
+  right: clamp(-60px, -8vw, -20px);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.background-accent--two {
+  bottom: clamp(-90px, -8vw, -30px);
+  left: clamp(-90px, -8vw, -30px);
+  background: rgba(36, 126, 214, 0.45);
+}
+
+.login-card {
+  position: relative;
+  z-index: 2;
+  width: min(420px, 100%);
+  padding: clamp(2rem, 4vw, 3rem);
+  background: linear-gradient(180deg, #ffffff 0%, #f5f7fa 100%);
+  border-radius: 24px;
+  box-shadow: 0 24px 60px rgba(3, 15, 32, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.login-card__header {
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #1f3c88, #2f63ff);
-  color: #fff;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.login-card__logo {
+  width: clamp(60px, 14vw, 88px);
+  height: auto;
+}
+
+.login-card__header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
   font-weight: 700;
-  font-size: 18px;
+  color: #0a2245;
+  letter-spacing: -0.02em;
 }
 
-.brand__title {
-  font-size: 14px;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.login-card h1 {
-  font-size: 32px;
-  line-height: 1.2;
-  font-weight: 600;
-}
-
-.login-card p {
-  color: rgba(240, 243, 255, 0.7);
+.login-card__subtitle {
+  color: rgba(9, 35, 70, 0.75);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: center;
 }
 
 .login-form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 1rem;
 }
 
-.login-form label {
+.login-form__field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: 14px;
-  color: rgba(240, 243, 255, 0.85);
+  gap: 0.35rem;
+  color: rgba(9, 35, 70, 0.78);
+  font-size: 0.95rem;
 }
 
-.login-form input {
-  background: rgba(10, 15, 42, 0.9);
-  border: 1px solid rgba(77, 95, 171, 0.6);
+.login-form__field input[type='email'],
+.login-form__field input[type='password'],
+.password-input input[type='text'] {
+  width: 100%;
+  padding: 0.9rem 1rem;
   border-radius: 14px;
-  padding: 14px 16px;
-  color: #f4f7ff;
-  font-size: 15px;
+  border: 1px solid rgba(9, 35, 70, 0.12);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #091f3a;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.login-form input:focus {
+.login-form__field input[type='email']:focus,
+.login-form__field input[type='password']:focus,
+.password-input input[type='text']:focus {
   outline: none;
-  border-color: #5d8dff;
-  box-shadow: 0 0 0 3px rgba(93, 141, 255, 0.25);
+  border-color: rgba(21, 78, 138, 0.5);
+  box-shadow: 0 0 0 4px rgba(21, 78, 138, 0.15);
 }
 
-.form-footer {
+.password-input {
+  position: relative;
+  display: flex;
+}
+
+.password-input input {
+  flex: 1;
+}
+
+.password-input__toggle {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  color: rgba(9, 35, 70, 0.6);
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.25rem;
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+}
+
+.password-input__toggle:focus-visible {
+  outline: 2px solid rgba(21, 78, 138, 0.5);
+  outline-offset: 2px;
+}
+
+.password-input__toggle svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.login-form__actions {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 13px;
-  color: rgba(240, 243, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.login-form__error {
+  margin: -0.25rem 0 0;
+  color: #d93025;
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .remember {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
+  color: rgba(9, 35, 70, 0.75);
 }
 
-.toggle-password {
-  background: none;
-  border: none;
-  color: #7ea2ff;
-  cursor: pointer;
-  font-size: 13px;
-  padding: 0;
+.remember input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #154e8a;
 }
 
-.form-footer a,
-.login-links a {
-  color: #7ea2ff;
-}
-
-.form-error {
-  background: rgba(255, 90, 90, 0.12);
-  border: 1px solid rgba(255, 138, 138, 0.4);
-  color: #ffd6d6;
-  padding: 12px 14px;
-  border-radius: 12px;
-  font-size: 13px;
-}
-
-.login-form button[type='submit'] {
-  margin-top: 8px;
-  background: linear-gradient(135deg, #3558ff, #1f3c88);
-  color: #fff;
-  border: none;
+.button {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.95rem 1.5rem;
   border-radius: 16px;
-  padding: 16px;
-  font-size: 16px;
+  border: none;
   font-weight: 600;
+  font-size: 1rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.login-form button[type='submit']:hover {
+.button--primary {
+  background: linear-gradient(135deg, #0b2c59 0%, #154e8a 100%);
+  color: #ffffff;
+  box-shadow: 0 18px 40px rgba(11, 44, 89, 0.35);
+}
+
+.button--primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 30px rgba(12, 21, 59, 0.35);
+  box-shadow: 0 20px 48px rgba(11, 44, 89, 0.4);
 }
 
-.login-links {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: rgba(240, 243, 255, 0.75);
+.button--primary:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(11, 44, 89, 0.3);
 }
 
-.login-card__preview {
-  position: relative;
-  background: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=900&q=80')
-    center/cover;
-  min-height: 320px;
+.button[disabled] {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
-.preview-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(9, 15, 43, 0.65), rgba(15, 24, 59, 0.95));
-  color: #f4f7ff;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: 48px;
-  gap: 16px;
+.login-form__help {
+  text-align: center;
+  color: rgba(9, 35, 70, 0.7);
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
-.login-hint {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  padding: 16px;
-  font-size: 13px;
-  color: rgba(244, 247, 255, 0.9);
-}
-
-.login-hint ul {
-  margin-top: 8px;
-  display: grid;
-  gap: 6px;
-  list-style: none;
-  padding: 0;
-}
-
-.login-hint strong {
+.link {
+  color: #154e8a;
   font-weight: 600;
+  text-decoration: none;
 }
 
-@media (max-width: 768px) {
-  .login-card {
-    border-radius: 24px;
+.link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .page {
+    padding: 2rem;
   }
 
-  .login-card__info,
-  .preview-overlay {
-    padding: 32px 24px;
+  .login-card {
+    padding: 2.25rem;
   }
 }
 
-@media (max-width: 520px) {
-  .login-card {
-    grid-template-columns: 1fr;
+@media (max-width: 640px) {
+  .page {
+    padding: 1.5rem;
   }
 
-  .login-card__preview {
-    order: -1;
+  .background-accent {
+    width: clamp(140px, 40vw, 220px);
+    height: clamp(140px, 40vw, 220px);
+    filter: blur(45px);
+  }
+
+  .login-card {
+    padding: 1.85rem;
+    border-radius: 20px;
+    gap: 1.5rem;
+  }
+
+  .login-card__subtitle {
+    font-size: 0.9rem;
+  }
+
+  .login-form__actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .button {
+    padding: 0.85rem 1.25rem;
+    border-radius: 14px;
+  }
+}
+
+@media (max-width: 420px) {
+  .page {
+    padding: 1.25rem;
+  }
+
+  .login-card {
+    padding: 1.65rem;
+  }
+
+  .login-card__header h1 {
+    font-size: 1.65rem;
+  }
+
+  .login-card__subtitle {
+    font-size: 0.85rem;
+  }
+
+  .login-form__field span {
+    font-size: 0.85rem;
+  }
+
+  .login-form__field input[type='email'],
+  .login-form__field input[type='password'],
+  .password-input input[type='text'] {
+    padding: 0.8rem 0.9rem;
+    font-size: 0.95rem;
+  }
+
+  .password-input__toggle {
+    right: 0.6rem;
+    font-size: 0.8rem;
+  }
+
+  .remember span,
+  .login-form__help,
+  .link,
+  .login-form__actions {
+    font-size: 0.85rem;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- add a lightweight auth utility and router guards so the admin and pegawai dashboards require a logged in demo user
- enhance the login screen with dummy account validation, error handling, and password visibility toggle for easier testing
- document the provided demo credentials in the README for quick reference

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68df494b0c788321b54389ee41a44382