### PR TITLE
Focus dashboards on local employee data management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup
 
-[VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+[VS Code](https://code.visualstudio.com/) + [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and
+ disable Vetur).
 
 ## Recommended Browser Setup
 
 - Chromium-based browsers (Chrome, Edge, Brave, etc.):
-  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) 
+  - [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
   - [Turn on Custom Object Formatter in Chrome DevTools](http://bit.ly/object-formatters)
 - Firefox:
   - [Vue.js devtools](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
@@ -36,3 +37,18 @@ npm run dev
 ```sh
 npm run build
 ```
+
+## Akun Demo
+
+Gunakan akun berikut untuk mencoba tampilan dashboard:
+
+| Peran    | Email            | Kata Sandi  |
+|----------|------------------|-------------|
+| Admin    | admin@amk.com    | admin123    |
+| Pegawai  | pegawai@amk.com  | pegawai123  |
+
+## Manajemen Data Pegawai (Lokal)
+
+- Data pegawai, termasuk email, kata sandi demo, dan field tambahan yang dibuat admin, tersimpan di browser melalui `localStorage`.
+- Admin dapat menambah/mengubah/menghapus pegawai, mengatur jumlah baris per halaman (10, 20, 30, 40), mencari pegawai, dan membuat field biodata kustom yang otomatis tersedia di akun pegawai.
+- Pegawai dapat memperbarui data yang relevan seperti kontak, alamat, rekening, kontak darurat, serta field tambahan yang ditambahkan admin. Field yang bersifat tetap seperti nomor pegawai tidak dapat diubah.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "amk-portal3.0",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.22"
+        "vue": "^3.5.22",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -1434,6 +1435,12 @@
         "@vue/shared": "3.5.22"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/devtools-core": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.2.tgz",
@@ -2789,6 +2796,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.22"
+    "vue": "^3.5.22",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,47 +1,14 @@
-<script setup>
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
-</script>
-
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-    </div>
-  </header>
-
-  <main>
-    <TheWelcome />
-  </main>
+  <RouterView />
 </template>
 
-<style scoped>
-header {
-  line-height: 1.5;
-}
+<script setup>
+import { RouterView } from 'vue-router'
+</script>
 
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
+<style>
+:global(body) {
+  background: #f3f6ff;
+  color: #1a1f36;
 }
 </style>

--- a/src/assets/amk-logo.svg
+++ b/src/assets/amk-logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">AMK Portal Logo</title>
+  <desc id="desc">Stylized AMK lettering inside a rounded navy gradient badge.</desc>
+  <defs>
+    <linearGradient id="badgeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b2c59" />
+      <stop offset="100%" stop-color="#154e8a" />
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="110" height="110" rx="28" fill="url(#badgeGradient)" />
+  <path
+    d="M28 82V38h14l18 25 18-25h14v44h-12V57l-20 25-20-25v25H28Z"
+    fill="#ffffff"
+  />
+  <circle cx="60" cy="34" r="6" fill="#24a6ff" />
+</svg>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,35 +1,31 @@
 @import './base.css';
 
+:root {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #1b2142;
+  background-color: #f3f6ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f3f6ff;
+}
+
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  font-weight: normal;
+  width: 100%;
+  min-height: 100vh;
 }
 
-a,
-.green {
+a {
+  color: inherit;
   text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
-  transition: 0.4s;
-  padding: 3px;
 }
 
-@media (hover: hover) {
-  a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
-  }
+a:hover {
+  text-decoration: underline;
 }
 
-@media (min-width: 1024px) {
-  body {
-    display: flex;
-    place-items: center;
-  }
-
-  #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    padding: 0 2rem;
-  }
+button {
+  font-family: inherit;
 }

--- a/src/components/AdminEmployeeManager.vue
+++ b/src/components/AdminEmployeeManager.vue
@@ -42,11 +42,18 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="employee in paginatedEmployees" :key="employee.id">
+          <tr
+            v-for="employee in paginatedEmployees"
+            :key="employee.id"
+            :class="{ 'is-active': employee.id === selectedEmployeeId }"
+            @click="selectEmployee(employee.id)"
+          >
             <td>{{ employee.employeeNumber }}</td>
             <td>
               <div class="table-name">
-                <strong>{{ employee.name }}</strong>
+                <button type="button" class="table-name__trigger" @click.stop="selectEmployee(employee.id)">
+                  <strong>{{ employee.name }}</strong>
+                </button>
                 <span>{{ employee.phone || 'Belum diisi' }}</span>
               </div>
             </td>
@@ -56,8 +63,8 @@
             <td class="password">{{ employee.password }}</td>
             <td>
               <div class="row-actions">
-                <button type="button" class="link" @click="openEditForm(employee)">Ubah</button>
-                <button type="button" class="link link--danger" @click="confirmRemoval(employee)">Hapus</button>
+                <button type="button" class="link" @click.stop="openEditForm(employee)">Ubah</button>
+                <button type="button" class="link link--danger" @click.stop="confirmRemoval(employee)">Hapus</button>
               </div>
             </td>
           </tr>
@@ -67,6 +74,112 @@
         </tbody>
       </table>
     </div>
+
+    <section v-if="selectedEmployee" class="employee-detail">
+      <header class="employee-detail__header">
+        <div>
+          <h3>{{ selectedEmployee.name }}</h3>
+          <p>
+            {{ selectedEmployee.employeeNumber }} •
+            {{ selectedEmployee.department }}
+          </p>
+        </div>
+        <div class="employee-detail__actions">
+          <button type="button" class="button button--ghost" @click="openEditForm(selectedEmployee)">
+            Ubah data
+          </button>
+          <button type="button" class="button button--danger" @click="confirmRemoval(selectedEmployee)">
+            Hapus pegawai
+          </button>
+        </div>
+      </header>
+
+      <div class="employee-detail__cards">
+        <article class="detail-card">
+          <h4>Profil</h4>
+          <ul>
+            <li>
+              <span>Jabatan</span>
+              <strong>{{ selectedEmployee.position }}</strong>
+            </li>
+            <li>
+              <span>Departemen</span>
+              <strong>{{ selectedEmployee.department }}</strong>
+            </li>
+            <li>
+              <span>Tanggal bergabung</span>
+              <strong>{{ formatDate(selectedEmployee.joinDate) }}</strong>
+            </li>
+            <li>
+              <span>Tanggal lahir</span>
+              <strong>{{ formatDate(selectedEmployee.dateOfBirth) }}</strong>
+            </li>
+          </ul>
+        </article>
+
+        <article class="detail-card">
+          <h4>Kontak & Darurat</h4>
+          <ul>
+            <li>
+              <span>Nomor telepon</span>
+              <strong>{{ selectedEmployee.phone || 'Belum diisi' }}</strong>
+            </li>
+            <li>
+              <span>Alamat domisili</span>
+              <strong>{{ selectedEmployee.address || 'Belum diisi' }}</strong>
+            </li>
+            <li>
+              <span>Kontak darurat</span>
+              <strong>{{ selectedEmployee.emergencyContactName || 'Belum diisi' }}</strong>
+            </li>
+            <li>
+              <span>Nomor darurat</span>
+              <strong>{{ selectedEmployee.emergencyContactPhone || 'Belum diisi' }}</strong>
+            </li>
+          </ul>
+        </article>
+
+        <article class="detail-card">
+          <h4>Akun Portal & Payroll</h4>
+          <ul>
+            <li>
+              <span>Email</span>
+              <strong>{{ selectedEmployee.email }}</strong>
+            </li>
+            <li>
+              <span>Kata sandi</span>
+              <strong class="detail-card__password">{{ selectedEmployee.password }}</strong>
+            </li>
+            <li>
+              <span>Bank</span>
+              <strong>{{ selectedEmployee.bankName || 'Belum diisi' }}</strong>
+            </li>
+            <li>
+              <span>Nomor rekening</span>
+              <strong>{{ selectedEmployee.bankAccount || 'Belum diisi' }}</strong>
+            </li>
+          </ul>
+          <p class="detail-card__hint">
+            Kredensial portal otomatis tersedia di akun pegawai dan dapat diubah sewaktu-waktu.
+          </p>
+        </article>
+
+        <article v-if="customFields.length" class="detail-card">
+          <h4>Field tambahan</h4>
+          <ul>
+            <li v-for="field in customFields" :key="field.id">
+              <span>{{ field.label }}</span>
+              <strong>{{ selectedEmployee.customValues?.[field.key] || 'Belum diisi' }}</strong>
+            </li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section v-else class="employee-detail employee-detail--empty">
+      <h3>Pilih pegawai</h3>
+      <p>Pilih salah satu nama pegawai untuk melihat biodata lengkap dan kredensial portal.</p>
+    </section>
 
     <footer class="employee-manager__footer" v-if="filteredEmployees.length">
       <p>Menampilkan {{ startRow }}-{{ endRow }} dari {{ filteredEmployees.length }} pegawai</p>
@@ -79,8 +192,8 @@
 
     <transition name="fade">
       <div v-if="showForm" class="modal-backdrop" @click.self="closeForm">
-        <section class="modal">
-          <header class="modal__header">
+        <section class="modal" :style="modalTransformStyle">
+          <header class="modal__header" @pointerdown="handleHeaderPointerDown">
             <div>
               <h3>{{ isEditMode ? 'Ubah data pegawai' : 'Tambah pegawai baru' }}</h3>
               <p>Field kustom yang ditambahkan akan otomatis tersedia di akun pegawai.</p>
@@ -144,7 +257,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 
 import { useEmployeeStore } from '../utils/employeeStore'
 
@@ -168,6 +281,57 @@ const isEditMode = ref(false)
 const editingEmployeeId = ref('')
 const deletingEmployee = ref(null)
 const newFieldName = ref('')
+const selectedEmployeeId = ref('')
+
+const modalPosition = reactive({ x: 0, y: 0 })
+const dragState = reactive({ active: false, offsetX: 0, offsetY: 0 })
+
+const modalTransformStyle = computed(() => ({
+  transform: `translate3d(${modalPosition.x}px, ${modalPosition.y}px, 0)`
+}))
+
+const detachDragListeners = () => {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('pointermove', handlePointerMove)
+  window.removeEventListener('pointerup', endDrag)
+}
+
+const handlePointerMove = (event) => {
+  if (!dragState.active) return
+  modalPosition.x = event.clientX - dragState.offsetX
+  modalPosition.y = event.clientY - dragState.offsetY
+}
+
+const endDrag = () => {
+  if (!dragState.active) return
+  dragState.active = false
+  detachDragListeners()
+}
+
+const beginDrag = (event) => {
+  if (typeof event === 'undefined') return
+  if (typeof event.button !== 'undefined' && event.button !== 0) return
+  dragState.active = true
+  dragState.offsetX = event.clientX - modalPosition.x
+  dragState.offsetY = event.clientY - modalPosition.y
+  if (typeof window !== 'undefined') {
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', endDrag)
+  }
+  event.preventDefault()
+}
+
+const handleHeaderPointerDown = (event) => {
+  if (event.target?.closest('button')) return
+  beginDrag(event)
+}
+
+const resetModalPosition = () => {
+  modalPosition.x = 0
+  modalPosition.y = 0
+  dragState.active = false
+  detachDragListeners()
+}
 
 const baseFormState = () => ({
   employeeNumber: '',
@@ -233,6 +397,11 @@ const paginatedEmployees = computed(() => {
   return filteredEmployees.value.slice(start, start + pageSize.value)
 })
 
+const selectedEmployee = computed(() => {
+  if (!selectedEmployeeId.value) return null
+  return employees.value.find((employee) => employee.id === selectedEmployeeId.value) || null
+})
+
 const startRow = computed(() => {
   if (!filteredEmployees.value.length) return 0
   return (currentPage.value - 1) * pageSize.value + 1
@@ -241,6 +410,42 @@ const startRow = computed(() => {
 const endRow = computed(() => {
   return Math.min(currentPage.value * pageSize.value, filteredEmployees.value.length)
 })
+
+const ensureSelectedEmployee = () => {
+  const list = filteredEmployees.value
+  if (!list.length) {
+    selectedEmployeeId.value = ''
+    return
+  }
+  if (!list.some((employee) => employee.id === selectedEmployeeId.value)) {
+    selectedEmployeeId.value = list[0].id
+  }
+}
+
+const ensureSelectionInPage = () => {
+  const list = paginatedEmployees.value
+  if (!list.length) return
+  if (!list.some((employee) => employee.id === selectedEmployeeId.value)) {
+    selectedEmployeeId.value = list[0].id
+  }
+}
+
+watch(filteredEmployees, ensureSelectedEmployee, { immediate: true })
+watch(paginatedEmployees, ensureSelectionInPage)
+watch(totalPages, (value) => {
+  if (currentPage.value > value) {
+    currentPage.value = value
+    ensureSelectionInPage()
+  }
+})
+
+const selectEmployee = (id) => {
+  if (!id) {
+    selectedEmployeeId.value = ''
+    return
+  }
+  selectedEmployeeId.value = id
+}
 
 watch([searchQuery, pageSize], () => {
   currentPage.value = 1
@@ -265,12 +470,20 @@ watch(
   { deep: true }
 )
 
+watch(showForm, (value) => {
+  if (!value) {
+    resetModalPosition()
+  }
+})
+
 const goToPage = (page) => {
   const safePage = Math.min(Math.max(page, 1), totalPages.value)
   currentPage.value = safePage
+  ensureSelectionInPage()
 }
 
 const openCreateForm = () => {
+  resetModalPosition()
   Object.assign(formState, baseFormState())
   Object.keys(formCustomValues).forEach((key) => delete formCustomValues[key])
   customFields.value.forEach((field) => {
@@ -282,6 +495,7 @@ const openCreateForm = () => {
 }
 
 const openEditForm = (employee) => {
+  resetModalPosition()
   Object.assign(formState, baseFormState(), employee)
   Object.keys(formCustomValues).forEach((key) => delete formCustomValues[key])
   customFields.value.forEach((field) => {
@@ -302,12 +516,14 @@ const handleSubmit = () => {
     customValues: { ...formCustomValues }
   }
 
+  let targetId = editingEmployeeId.value
   if (isEditMode.value) {
     updateEmployee(editingEmployeeId.value, payload)
   } else {
-    addEmployee(payload)
+    targetId = addEmployee(payload)
   }
 
+  selectEmployee(targetId)
   closeForm()
 }
 
@@ -321,7 +537,12 @@ const cancelRemoval = () => {
 
 const handleRemoval = () => {
   if (deletingEmployee.value) {
-    removeEmployee(deletingEmployee.value.id)
+    const removedId = deletingEmployee.value.id
+    removeEmployee(removedId)
+    if (selectedEmployeeId.value === removedId) {
+      ensureSelectedEmployee()
+      ensureSelectionInPage()
+    }
   }
   deletingEmployee.value = null
 }
@@ -331,6 +552,19 @@ const handleAddField = () => {
   addCustomField(newFieldName.value)
   newFieldName.value = ''
 }
+
+const formatDate = (value) => {
+  if (!value) return 'Belum diisi'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric'
+  })
+}
+
+onBeforeUnmount(detachDragListeners)
 </script>
 
 <style scoped>
@@ -465,9 +699,34 @@ const handleAddField = () => {
   gap: 4px;
 }
 
+.table-name__trigger {
+  border: none;
+  background: none;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.table-name__trigger strong {
+  font-weight: 600;
+}
+
 .table-name span {
   font-size: 12px;
   color: #6a7190;
+}
+
+.table-wrapper tbody tr {
+  transition: background 0.2s ease;
+}
+
+.table-wrapper tbody tr.is-active {
+  background: rgba(31, 60, 136, 0.08);
+}
+
+.table-wrapper tbody tr.is-active .table-name__trigger strong {
+  color: #1f3c88;
 }
 
 .password {
@@ -560,6 +819,114 @@ const handleAddField = () => {
   color: #ffffff;
 }
 
+.employee-detail {
+  margin-top: 12px;
+  background: rgba(31, 60, 136, 0.06);
+  border-radius: 22px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.employee-detail__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.employee-detail__header h3 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.employee-detail__header p {
+  color: #6a7190;
+  font-size: 13px;
+}
+
+.employee-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.employee-detail__cards {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+  scroll-snap-type: x proximity;
+}
+
+.detail-card {
+  flex: 0 0 260px;
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: 0 16px 30px rgba(15, 28, 63, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  scroll-snap-align: start;
+}
+
+.detail-card h4 {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.detail-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-card li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-card span {
+  font-size: 12px;
+  color: #6a7190;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.detail-card strong {
+  font-size: 15px;
+  color: #1b2142;
+}
+
+.detail-card__password {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  letter-spacing: 0.5px;
+}
+
+.detail-card__hint {
+  margin-top: auto;
+  font-size: 12px;
+  color: #7f87aa;
+}
+
+.employee-detail--empty {
+  align-items: center;
+  text-align: center;
+  background: rgba(31, 60, 136, 0.04);
+  color: #6a7190;
+}
+
+.employee-detail--empty h3 {
+  color: #1b2142;
+  font-weight: 600;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -577,6 +944,8 @@ const handleAddField = () => {
   box-shadow: 0 24px 60px rgba(11, 28, 63, 0.25);
   display: flex;
   flex-direction: column;
+  position: relative;
+  will-change: transform;
 }
 
 .modal__header {
@@ -586,11 +955,17 @@ const handleAddField = () => {
   align-items: flex-start;
   gap: 12px;
   border-bottom: 1px solid rgba(31, 60, 136, 0.08);
+  cursor: grab;
+  user-select: none;
 }
 
 .modal__header h3 {
   font-size: 20px;
   font-weight: 600;
+}
+
+.modal__header:active {
+  cursor: grabbing;
 }
 
 .modal__header p {
@@ -708,6 +1083,27 @@ const handleAddField = () => {
 
   .custom-field {
     width: 100%;
+  }
+
+  .employee-detail {
+    padding: 20px;
+  }
+
+  .employee-detail__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .employee-detail__actions {
+    width: 100%;
+  }
+
+  .employee-detail__cards {
+    scroll-snap-type: x mandatory;
+  }
+
+  .detail-card {
+    flex: 0 0 min(280px, 86vw);
   }
 
   .modal {

--- a/src/components/AdminEmployeeManager.vue
+++ b/src/components/AdminEmployeeManager.vue
@@ -26,6 +26,22 @@
         <input v-model.trim="newFieldName" type="text" placeholder="Tambah field biodata baru" />
         <button type="submit" class="button">Tambah field</button>
       </form>
+      <div v-if="customFields.length" class="custom-field-list" aria-live="polite">
+        <p>Field aktif:</p>
+        <ul>
+          <li v-for="field in customFields" :key="field.id">
+            <span>{{ field.label }}</span>
+            <button
+              type="button"
+              class="custom-field-list__remove"
+              @click="handleRemoveField(field)"
+              :aria-label="`Hapus field ${field.label}`"
+            >
+              ×
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
 
     <div class="table-wrapper">
@@ -270,7 +286,8 @@ const {
   addEmployee,
   updateEmployee,
   removeEmployee,
-  addCustomField
+  addCustomField,
+  removeCustomField
 } = useEmployeeStore()
 
 const searchQuery = ref('')
@@ -439,6 +456,24 @@ watch(totalPages, (value) => {
   }
 })
 
+watch(
+  customFields,
+  (fields) => {
+    const keys = fields.map((field) => field.key)
+    fields.forEach((field) => {
+      if (typeof formCustomValues[field.key] === 'undefined') {
+        formCustomValues[field.key] = ''
+      }
+    })
+    Object.keys(formCustomValues).forEach((key) => {
+      if (!keys.includes(key)) {
+        delete formCustomValues[key]
+      }
+    })
+  },
+  { deep: true, immediate: true }
+)
+
 const selectEmployee = (id) => {
   if (!id) {
     selectedEmployeeId.value = ''
@@ -553,6 +588,12 @@ const handleAddField = () => {
   newFieldName.value = ''
 }
 
+const handleRemoveField = (field) => {
+  if (!field) return
+  removeCustomField(field.id)
+  delete formCustomValues[field.key]
+}
+
 const formatDate = (value) => {
   if (!value) return 'Belum diisi'
   const date = new Date(value)
@@ -665,6 +706,64 @@ onBeforeUnmount(detachDragListeners)
   border: 1px solid rgba(31, 60, 136, 0.15);
   background: rgba(248, 250, 255, 0.7);
   font-size: 14px;
+}
+
+.custom-field-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 16px;
+  background: rgba(31, 60, 136, 0.05);
+  border-radius: 16px;
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.custom-field-list p {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.custom-field-list ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.custom-field-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  font-size: 13px;
+  color: #1b2142;
+}
+
+.custom-field-list__remove {
+  background: none;
+  border: none;
+  color: #d95050;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.custom-field-list__remove:hover,
+.custom-field-list__remove:focus-visible {
+  color: #b63c3c;
+}
+
+.custom-field-list__remove:focus-visible {
+  outline: 2px solid rgba(217, 80, 80, 0.35);
+  outline-offset: 2px;
 }
 
 .table-wrapper {
@@ -946,6 +1045,8 @@ onBeforeUnmount(detachDragListeners)
   flex-direction: column;
   position: relative;
   will-change: transform;
+  max-height: min(90vh, 760px);
+  overflow: hidden;
 }
 
 .modal__header {
@@ -987,6 +1088,10 @@ onBeforeUnmount(detachDragListeners)
   display: flex;
   flex-direction: column;
   gap: 24px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  scroll-behavior: smooth;
+  scrollbar-gutter: stable;
 }
 
 .modal__grid {
@@ -1085,6 +1190,10 @@ onBeforeUnmount(detachDragListeners)
     width: 100%;
   }
 
+  .custom-field-list {
+    width: 100%;
+  }
+
   .employee-detail {
     padding: 20px;
   }
@@ -1107,8 +1216,7 @@ onBeforeUnmount(detachDragListeners)
   }
 
   .modal {
-    max-height: 90vh;
-    overflow-y: auto;
+    width: min(92vw, 100%);
   }
 }
 </style>

--- a/src/components/AdminEmployeeManager.vue
+++ b/src/components/AdminEmployeeManager.vue
@@ -1,0 +1,718 @@
+<template>
+  <section class="employee-manager">
+    <header class="employee-manager__header">
+      <div>
+        <h2>Data Pegawai</h2>
+        <p>Kelola biodata, kredensial, dan field tambahan untuk seluruh pegawai.</p>
+      </div>
+      <div class="employee-manager__actions">
+        <label class="page-size">
+          Tampilkan
+          <select v-model.number="pageSize">
+            <option v-for="option in pageOptions" :key="option" :value="option">{{ option }}</option>
+          </select>
+          baris
+        </label>
+        <button type="button" class="button button--primary" @click="openCreateForm">Tambah pegawai</button>
+      </div>
+    </header>
+
+    <div class="employee-manager__controls">
+      <div class="search">
+        <span class="search__icon">🔍</span>
+        <input v-model.trim="searchQuery" type="search" placeholder="Cari nama, nomor pegawai, departemen, atau email" />
+      </div>
+      <form class="custom-field" @submit.prevent="handleAddField">
+        <input v-model.trim="newFieldName" type="text" placeholder="Tambah field biodata baru" />
+        <button type="submit" class="button">Tambah field</button>
+      </form>
+    </div>
+
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>No. Pegawai</th>
+            <th>Nama</th>
+            <th>Departemen</th>
+            <th>Jabatan</th>
+            <th>Email</th>
+            <th>Kata sandi</th>
+            <th>Aksi</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="employee in paginatedEmployees" :key="employee.id">
+            <td>{{ employee.employeeNumber }}</td>
+            <td>
+              <div class="table-name">
+                <strong>{{ employee.name }}</strong>
+                <span>{{ employee.phone || 'Belum diisi' }}</span>
+              </div>
+            </td>
+            <td>{{ employee.department }}</td>
+            <td>{{ employee.position }}</td>
+            <td>{{ employee.email }}</td>
+            <td class="password">{{ employee.password }}</td>
+            <td>
+              <div class="row-actions">
+                <button type="button" class="link" @click="openEditForm(employee)">Ubah</button>
+                <button type="button" class="link link--danger" @click="confirmRemoval(employee)">Hapus</button>
+              </div>
+            </td>
+          </tr>
+          <tr v-if="!paginatedEmployees.length">
+            <td colspan="7" class="empty">Belum ada data yang cocok dengan pencarian.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <footer class="employee-manager__footer" v-if="filteredEmployees.length">
+      <p>Menampilkan {{ startRow }}-{{ endRow }} dari {{ filteredEmployees.length }} pegawai</p>
+      <div class="pagination">
+        <button type="button" :disabled="currentPage === 1" @click="goToPage(currentPage - 1)">Sebelumnya</button>
+        <span>Halaman {{ currentPage }} dari {{ totalPages }}</span>
+        <button type="button" :disabled="currentPage === totalPages" @click="goToPage(currentPage + 1)">Berikutnya</button>
+      </div>
+    </footer>
+
+    <transition name="fade">
+      <div v-if="showForm" class="modal-backdrop" @click.self="closeForm">
+        <section class="modal">
+          <header class="modal__header">
+            <div>
+              <h3>{{ isEditMode ? 'Ubah data pegawai' : 'Tambah pegawai baru' }}</h3>
+              <p>Field kustom yang ditambahkan akan otomatis tersedia di akun pegawai.</p>
+            </div>
+            <button type="button" class="modal__close" @click="closeForm">×</button>
+          </header>
+
+          <form class="modal__form" @submit.prevent="handleSubmit">
+            <div class="modal__grid">
+              <label v-for="field in formFields" :key="field.key" :class="['form-field', { 'form-field--full': field.fullWidth }]
+                ">
+                <span>{{ field.label }}</span>
+                <input
+                  v-if="field.type !== 'textarea'"
+                  v-model="formState[field.key]"
+                  :type="field.type"
+                  :required="field.required"
+                  :disabled="isEditMode && field.readonlyOnEdit"
+                />
+                <textarea
+                  v-else
+                  v-model="formState[field.key]"
+                  :required="field.required"
+                  rows="3"
+                ></textarea>
+              </label>
+            </div>
+
+            <div v-if="customFields.length" class="modal__custom">
+              <h4>Field tambahan</h4>
+              <div class="modal__grid">
+                <label v-for="field in customFields" :key="field.id" class="form-field form-field--full">
+                  <span>{{ field.label }}</span>
+                  <input v-model="formCustomValues[field.key]" type="text" />
+                </label>
+              </div>
+            </div>
+
+            <footer class="modal__footer">
+              <button type="button" class="button button--ghost" @click="closeForm">Batal</button>
+              <button type="submit" class="button button--primary">Simpan</button>
+            </footer>
+          </form>
+        </section>
+      </div>
+    </transition>
+
+    <transition name="fade">
+      <div v-if="deletingEmployee" class="modal-backdrop" @click.self="cancelRemoval">
+        <section class="confirm-modal">
+          <h3>Hapus data pegawai?</h3>
+          <p>Data <strong>{{ deletingEmployee.name }}</strong> akan dihapus dari daftar pegawai.</p>
+          <div class="confirm-modal__actions">
+            <button type="button" class="button button--ghost" @click="cancelRemoval">Batalkan</button>
+            <button type="button" class="button button--danger" @click="handleRemoval">Ya, hapus</button>
+          </div>
+        </section>
+      </div>
+    </transition>
+  </section>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch } from 'vue'
+
+import { useEmployeeStore } from '../utils/employeeStore'
+
+const pageOptions = [10, 20, 30, 40]
+
+const {
+  employees,
+  customFields,
+  sortedEmployees,
+  addEmployee,
+  updateEmployee,
+  removeEmployee,
+  addCustomField
+} = useEmployeeStore()
+
+const searchQuery = ref('')
+const pageSize = ref(pageOptions[0])
+const currentPage = ref(1)
+const showForm = ref(false)
+const isEditMode = ref(false)
+const editingEmployeeId = ref('')
+const deletingEmployee = ref(null)
+const newFieldName = ref('')
+
+const baseFormState = () => ({
+  employeeNumber: '',
+  name: '',
+  email: '',
+  password: '',
+  department: '',
+  position: '',
+  phone: '',
+  address: '',
+  joinDate: '',
+  bankName: '',
+  bankAccount: '',
+  emergencyContactName: '',
+  emergencyContactPhone: '',
+  dateOfBirth: ''
+})
+
+const formState = reactive(baseFormState())
+const formCustomValues = reactive({})
+
+const formFields = [
+  { key: 'employeeNumber', label: 'Nomor Pegawai', type: 'text', required: true, readonlyOnEdit: true },
+  { key: 'name', label: 'Nama Lengkap', type: 'text', required: true },
+  { key: 'email', label: 'Email', type: 'email', required: true },
+  { key: 'password', label: 'Kata Sandi', type: 'text', required: true },
+  { key: 'department', label: 'Departemen', type: 'text', required: true },
+  { key: 'position', label: 'Jabatan', type: 'text', required: true },
+  { key: 'phone', label: 'Nomor Telepon', type: 'tel', required: false },
+  { key: 'address', label: 'Alamat Domisili', type: 'textarea', required: false, fullWidth: true },
+  { key: 'dateOfBirth', label: 'Tanggal Lahir', type: 'date', required: false },
+  { key: 'joinDate', label: 'Tanggal Bergabung', type: 'date', required: true },
+  { key: 'bankName', label: 'Bank', type: 'text', required: false },
+  { key: 'bankAccount', label: 'Nomor Rekening', type: 'text', required: false },
+  { key: 'emergencyContactName', label: 'Kontak Darurat', type: 'text', required: false },
+  { key: 'emergencyContactPhone', label: 'Nomor Kontak Darurat', type: 'tel', required: false }
+]
+
+const filteredEmployees = computed(() => {
+  const term = searchQuery.value.toLowerCase()
+  if (!term) return sortedEmployees.value
+  return sortedEmployees.value.filter((employee) => {
+    return [
+      employee.employeeNumber,
+      employee.name,
+      employee.department,
+      employee.position,
+      employee.email
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(term)
+  })
+})
+
+const totalPages = computed(() => {
+  if (!filteredEmployees.value.length) return 1
+  return Math.ceil(filteredEmployees.value.length / pageSize.value)
+})
+
+const paginatedEmployees = computed(() => {
+  const start = (currentPage.value - 1) * pageSize.value
+  return filteredEmployees.value.slice(start, start + pageSize.value)
+})
+
+const startRow = computed(() => {
+  if (!filteredEmployees.value.length) return 0
+  return (currentPage.value - 1) * pageSize.value + 1
+})
+
+const endRow = computed(() => {
+  return Math.min(currentPage.value * pageSize.value, filteredEmployees.value.length)
+})
+
+watch([searchQuery, pageSize], () => {
+  currentPage.value = 1
+})
+
+watch(pageSize, () => {
+  if (pageOptions.indexOf(pageSize.value) === -1) {
+    pageSize.value = pageOptions[0]
+  }
+})
+
+watch(
+  customFields,
+  () => {
+    if (!showForm.value) return
+    customFields.value.forEach((field) => {
+      if (!(field.key in formCustomValues)) {
+        formCustomValues[field.key] = ''
+      }
+    })
+  },
+  { deep: true }
+)
+
+const goToPage = (page) => {
+  const safePage = Math.min(Math.max(page, 1), totalPages.value)
+  currentPage.value = safePage
+}
+
+const openCreateForm = () => {
+  Object.assign(formState, baseFormState())
+  Object.keys(formCustomValues).forEach((key) => delete formCustomValues[key])
+  customFields.value.forEach((field) => {
+    formCustomValues[field.key] = ''
+  })
+  isEditMode.value = false
+  editingEmployeeId.value = ''
+  showForm.value = true
+}
+
+const openEditForm = (employee) => {
+  Object.assign(formState, baseFormState(), employee)
+  Object.keys(formCustomValues).forEach((key) => delete formCustomValues[key])
+  customFields.value.forEach((field) => {
+    formCustomValues[field.key] = employee.customValues?.[field.key] || ''
+  })
+  isEditMode.value = true
+  editingEmployeeId.value = employee.id
+  showForm.value = true
+}
+
+const closeForm = () => {
+  showForm.value = false
+}
+
+const handleSubmit = () => {
+  const payload = {
+    ...formState,
+    customValues: { ...formCustomValues }
+  }
+
+  if (isEditMode.value) {
+    updateEmployee(editingEmployeeId.value, payload)
+  } else {
+    addEmployee(payload)
+  }
+
+  closeForm()
+}
+
+const confirmRemoval = (employee) => {
+  deletingEmployee.value = employee
+}
+
+const cancelRemoval = () => {
+  deletingEmployee.value = null
+}
+
+const handleRemoval = () => {
+  if (deletingEmployee.value) {
+    removeEmployee(deletingEmployee.value.id)
+  }
+  deletingEmployee.value = null
+}
+
+const handleAddField = () => {
+  if (!newFieldName.value) return
+  addCustomField(newFieldName.value)
+  newFieldName.value = ''
+}
+</script>
+
+<style scoped>
+.employee-manager {
+  background: #ffffff;
+  border-radius: 26px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 20px 45px rgba(15, 28, 63, 0.08);
+}
+
+.employee-manager__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.employee-manager__header h2 {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.employee-manager__header p {
+  color: #6a7190;
+  font-size: 14px;
+}
+
+.employee-manager__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(31, 60, 136, 0.08);
+  font-size: 14px;
+  color: #1b2142;
+}
+
+.page-size select {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  color: inherit;
+  cursor: pointer;
+}
+
+.employee-manager__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.search {
+  position: relative;
+  flex: 1 1 320px;
+}
+
+.search__icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 16px;
+  color: #7f87aa;
+}
+
+.search input {
+  width: 100%;
+  padding: 12px 16px 12px 42px;
+  border-radius: 16px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  background: rgba(248, 250, 255, 0.7);
+  font-size: 14px;
+  color: #1b2142;
+}
+
+.custom-field {
+  display: flex;
+  gap: 12px;
+  flex: 1 1 280px;
+}
+
+.custom-field input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  background: rgba(248, 250, 255, 0.7);
+  font-size: 14px;
+}
+
+.table-wrapper {
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  border-radius: 20px;
+  overflow: hidden;
+}
+
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-wrapper thead {
+  background: rgba(31, 60, 136, 0.08);
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  padding: 14px 18px;
+  text-align: left;
+  font-size: 14px;
+}
+
+.table-wrapper tbody tr:nth-child(even) {
+  background: rgba(250, 252, 255, 0.6);
+}
+
+.table-name {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.table-name span {
+  font-size: 12px;
+  color: #6a7190;
+}
+
+.password {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 13px;
+}
+
+.row-actions {
+  display: inline-flex;
+  gap: 10px;
+}
+
+.link {
+  border: none;
+  background: none;
+  color: #1f3c88;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.link--danger {
+  color: #d95050;
+}
+
+.empty {
+  text-align: center;
+  padding: 24px;
+  color: #7f87aa;
+}
+
+.employee-manager__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  font-size: 13px;
+  color: #6a7190;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pagination button {
+  border: none;
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(31, 60, 136, 0.12);
+  color: #1b2142;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 14px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #0b2c59 0%, #154e8a 100%);
+  color: #ffffff;
+}
+
+.button--ghost {
+  background: rgba(31, 60, 136, 0.08);
+  color: #1b2142;
+}
+
+.button--danger {
+  background: #d95050;
+  color: #ffffff;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 16, 35, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  z-index: 80;
+}
+
+.modal {
+  width: min(780px, 100%);
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 24px 60px rgba(11, 28, 63, 0.25);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__header {
+  padding: 24px 28px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  border-bottom: 1px solid rgba(31, 60, 136, 0.08);
+}
+
+.modal__header h3 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.modal__header p {
+  color: #6a7190;
+  font-size: 13px;
+}
+
+.modal__close {
+  border: none;
+  background: none;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  color: #7f87aa;
+}
+
+.modal__form {
+  padding: 24px 28px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.modal__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-field span {
+  font-size: 13px;
+  color: #1b2142;
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field textarea {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  background: rgba(248, 250, 255, 0.7);
+  font-size: 14px;
+  color: #1b2142;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.form-field--full {
+  grid-column: 1 / -1;
+}
+
+.modal__custom h4 {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.modal__footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.confirm-modal {
+  width: min(380px, 100%);
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  text-align: center;
+}
+
+.confirm-modal__actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 768px) {
+  .employee-manager__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .employee-manager__actions {
+    justify-content: space-between;
+  }
+
+  .employee-manager__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .custom-field {
+    width: 100%;
+  }
+
+  .modal {
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+}
+</style>

--- a/src/components/DashboardLayout.vue
+++ b/src/components/DashboardLayout.vue
@@ -313,9 +313,11 @@ const progressStyle = computed(() => {
   display: grid;
   grid-template-columns: 260px 1fr;
   min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(180deg, #f5f7ff 0%, #eef1ff 100%);
   color: #1b2142;
   position: relative;
+  overflow: hidden;
 }
 
 .dashboard--sidebar-open {
@@ -333,6 +335,9 @@ const progressStyle = computed(() => {
   transition: transform 0.3s ease;
   position: relative;
   z-index: 40;
+  height: 100vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .sidebar__close {
@@ -520,6 +525,9 @@ const progressStyle = computed(() => {
   flex-direction: column;
   gap: 28px;
   position: relative;
+  height: 100vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .dashboard__header {

--- a/src/components/DashboardLayout.vue
+++ b/src/components/DashboardLayout.vue
@@ -19,12 +19,12 @@
       <div class="sidebar__role">{{ role }}</div>
       <nav class="sidebar__menu">
         <button
-          v-for="(item, index) in menuItems"
-          :key="item.label"
+          v-for="item in menuEntries"
+          :key="item._key"
           type="button"
           class="menu-item"
-          :class="{ active: index === 0 }"
-          @click="handleMenuClick"
+          :class="{ active: item._key === currentMenuKey }"
+          @click="() => selectMenu(item._key)"
         >
           <span class="menu-item__bullet" />
           <div class="menu-item__text">
@@ -67,7 +67,7 @@
         </div>
       </header>
 
-      <section v-if="summaryCards.length" class="cards-grid">
+      <section v-if="summaryCards.length && isOverview" class="cards-grid">
         <article v-for="card in summaryCards" :key="card.title" class="summary-card">
           <div class="summary-card__icon" :style="{ '--card-color': card.accent || accentColor }">
             <span>{{ card.icon }}</span>
@@ -80,11 +80,18 @@
         </article>
       </section>
 
-      <section v-if="$slots.content" class="dashboard__slot">
-        <slot name="content" />
+      <section v-if="isOverview && $slots.overview" class="dashboard__slot">
+        <slot name="overview" />
       </section>
 
-      <div v-if="recentItems.length || (stats && stats.items && stats.items.length)" class="content-grid">
+      <section v-else-if="activeSlotName" class="dashboard__slot dashboard__slot--fill">
+        <slot :name="activeSlotName" />
+      </section>
+
+      <div
+        v-if="isOverview && (recentItems.length || (stats && stats.items && stats.items.length))"
+        class="content-grid"
+      >
         <section v-if="recentItems.length" class="recent-card">
           <div class="card-header">
             <div>
@@ -151,7 +158,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
 
 const props = defineProps({
   userName: { type: String, required: true },
@@ -172,10 +179,77 @@ const props = defineProps({
     default: () => []
   },
   quickActionsTitle: { type: String, default: 'Aksi cepat' },
-  accentColor: { type: String, default: '#1f3c88' }
+  accentColor: { type: String, default: '#1f3c88' },
+  activeMenuKey: { type: String, default: '' },
+  overviewKey: { type: String, default: '' }
 })
 
-const emit = defineEmits(['logout'])
+const emit = defineEmits(['logout', 'update:activeMenuKey'])
+
+const slots = useSlots()
+
+const menuEntries = computed(() =>
+  props.menuItems.map((item, index) => ({
+    ...item,
+    _key: item.key || item.id || item.value || item.label || `menu-${index}`
+  }))
+)
+
+const internalActiveKey = ref('')
+
+const fallbackKey = computed(() => menuEntries.value[0]?._key || '')
+
+const currentMenuKey = computed({
+  get() {
+    return props.activeMenuKey || internalActiveKey.value || fallbackKey.value
+  },
+  set(value) {
+    internalActiveKey.value = value
+    emit('update:activeMenuKey', value)
+  }
+})
+
+watch(
+  () => props.activeMenuKey,
+  (value) => {
+    if (value) {
+      internalActiveKey.value = value
+    }
+  }
+)
+
+watch(
+  menuEntries,
+  (entries) => {
+    if (!entries.length) {
+      internalActiveKey.value = ''
+      return
+    }
+    const keys = entries.map((entry) => entry._key)
+    if (!keys.includes(currentMenuKey.value)) {
+      internalActiveKey.value = props.activeMenuKey || fallbackKey.value
+    }
+    if (!internalActiveKey.value) {
+      internalActiveKey.value = fallbackKey.value
+    }
+  },
+  { immediate: true }
+)
+
+const overviewKey = computed(() => props.overviewKey || fallbackKey.value)
+
+const isOverview = computed(() => currentMenuKey.value === overviewKey.value)
+
+const activeSlotName = computed(() => {
+  if (isOverview.value) return ''
+  if (currentMenuKey.value && slots[currentMenuKey.value]) {
+    return currentMenuKey.value
+  }
+  if (slots.content) {
+    return 'content'
+  }
+  return ''
+})
 
 const isSidebarOpen = ref(false)
 
@@ -196,7 +270,9 @@ const closeSidebar = () => {
   isSidebarOpen.value = false
 }
 
-const handleMenuClick = () => {
+const selectMenu = (key) => {
+  if (!key) return
+  currentMenuKey.value = key
   closeSidebar()
 }
 
@@ -528,6 +604,10 @@ const progressStyle = computed(() => {
   gap: 24px;
 }
 
+.dashboard__slot--fill {
+  min-height: 0;
+}
+
 .summary-card {
   background: #ffffff;
   border-radius: 22px;
@@ -587,6 +667,7 @@ const progressStyle = computed(() => {
   display: flex;
   flex-direction: column;
   gap: 22px;
+  overflow: hidden;
 }
 
 .card-header {
@@ -873,6 +954,13 @@ const progressStyle = computed(() => {
 
   .sidebar-toggle {
     display: inline-flex;
+  }
+
+  .recent-card,
+  .stats-card {
+    max-height: 65vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/src/components/DashboardLayout.vue
+++ b/src/components/DashboardLayout.vue
@@ -1,0 +1,939 @@
+<template>
+  <div
+    class="dashboard"
+    :class="{ 'dashboard--sidebar-open': isSidebarOpen }"
+    :style="{ '--accent-color': accentColor }"
+  >
+    <aside class="sidebar">
+      <button type="button" class="sidebar__close" @click="closeSidebar" aria-label="Tutup menu">
+        <span />
+        <span />
+      </button>
+      <div class="sidebar__brand">
+        <div class="brand-icon">AMK</div>
+        <div class="brand-info">
+          <span class="brand-name">AMK Payroll</span>
+          <span class="brand-tag">Terpercaya sejak 2020</span>
+        </div>
+      </div>
+      <div class="sidebar__role">{{ role }}</div>
+      <nav class="sidebar__menu">
+        <button
+          v-for="(item, index) in menuItems"
+          :key="item.label"
+          type="button"
+          class="menu-item"
+          :class="{ active: index === 0 }"
+          @click="handleMenuClick"
+        >
+          <span class="menu-item__bullet" />
+          <div class="menu-item__text">
+            <span class="menu-item__label">{{ item.label }}</span>
+            <span v-if="item.helper" class="menu-item__helper">{{ item.helper }}</span>
+          </div>
+        </button>
+      </nav>
+      <div class="sidebar__footer">
+        <button type="button" class="sidebar__logout" @click="handleLogout">
+          <span class="sidebar__logout-icon">⎋</span>
+          <span>Keluar</span>
+        </button>
+        <div class="sidebar__support">
+          <p>Ada kendala?</p>
+          <a href="#">Hubungi tim kami</a>
+        </div>
+      </div>
+    </aside>
+
+    <div v-if="isSidebarOpen" class="sidebar-backdrop" @click="closeSidebar" />
+
+    <main class="dashboard__main">
+      <header class="dashboard__header">
+        <button type="button" class="sidebar-toggle" @click="toggleSidebar" aria-label="Buka menu">
+          <span />
+          <span />
+          <span />
+        </button>
+        <div>
+          <p class="dashboard__greeting">{{ greeting }}</p>
+          <h1>Selamat datang, {{ userName }}</h1>
+        </div>
+        <div class="dashboard__profile">
+          <div class="profile-name">
+            <span class="profile-label">Peran</span>
+            <span class="profile-value">{{ role }}</span>
+          </div>
+          <div class="profile-avatar">{{ initials }}</div>
+        </div>
+      </header>
+
+      <section v-if="summaryCards.length" class="cards-grid">
+        <article v-for="card in summaryCards" :key="card.title" class="summary-card">
+          <div class="summary-card__icon" :style="{ '--card-color': card.accent || accentColor }">
+            <span>{{ card.icon }}</span>
+          </div>
+          <div class="summary-card__body">
+            <p class="summary-card__title">{{ card.title }}</p>
+            <h2 class="summary-card__value">{{ card.value }}</h2>
+            <p class="summary-card__meta" v-if="card.meta">{{ card.meta }}</p>
+          </div>
+        </article>
+      </section>
+
+      <section v-if="$slots.content" class="dashboard__slot">
+        <slot name="content" />
+      </section>
+
+      <div v-if="recentItems.length || (stats && stats.items && stats.items.length)" class="content-grid">
+        <section v-if="recentItems.length" class="recent-card">
+          <div class="card-header">
+            <div>
+              <h2>{{ recentTitle }}</h2>
+              <p>{{ recentSubtitle }}</p>
+            </div>
+            <button type="button">Lihat semua</button>
+          </div>
+          <ul class="recent-list">
+            <li v-for="item in recentItems" :key="item.id || item.name" class="recent-item">
+              <div class="recent-item__info">
+                <span class="recent-item__name">{{ item.name }}</span>
+                <span class="recent-item__desc">{{ item.description }}</span>
+              </div>
+              <div class="recent-item__meta">
+                <span class="recent-item__amount">{{ item.amount }}</span>
+                <span class="badge" :class="`badge--${item.status.tone}`">{{ item.status.label }}</span>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section v-if="stats && stats.items && stats.items.length" class="stats-card">
+          <div class="card-header">
+            <div>
+              <h2>{{ stats.title }}</h2>
+              <p>{{ stats.subtitle }}</p>
+            </div>
+            <span class="stats-card__period">{{ stats.period }}</span>
+          </div>
+
+          <div class="stats-card__body">
+            <div class="stats-card__chart" :style="progressStyle">
+              <div class="stats-card__chart-inner">
+                <span class="chart-value">{{ stats.total }}</span>
+                <span class="chart-label">{{ stats.totalLabel }}</span>
+              </div>
+            </div>
+            <ul class="stats-card__list">
+              <li v-for="item in stats.items" :key="item.label">
+                <span>{{ item.label }}</span>
+                <strong>{{ item.value }}</strong>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="quickActions.length" class="quick-actions">
+            <h3>{{ quickActionsTitle }}</h3>
+            <div class="quick-actions__grid">
+              <article v-for="action in quickActions" :key="action.label" class="quick-action">
+                <h4>{{ action.label }}</h4>
+                <p>{{ action.description }}</p>
+              </article>
+            </div>
+          </div>
+
+          <footer class="stats-card__footer">
+            <span>{{ stats.footer }}</span>
+          </footer>
+        </section>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  userName: { type: String, required: true },
+  role: { type: String, required: true },
+  greeting: { type: String, default: 'Semoga harimu menyenangkan! 👋' },
+  menuItems: { type: Array, required: true },
+  summaryCards: { type: Array, required: true },
+  recentTitle: { type: String, default: 'Aktivitas terkini' },
+  recentSubtitle: { type: String, default: 'Pantau update terbaru secara real-time.' },
+  recentItems: { type: Array, default: () => [] },
+  stats: {
+    type: Object,
+    required: true,
+    default: () => ({})
+  },
+  quickActions: {
+    type: Array,
+    default: () => []
+  },
+  quickActionsTitle: { type: String, default: 'Aksi cepat' },
+  accentColor: { type: String, default: '#1f3c88' }
+})
+
+const emit = defineEmits(['logout'])
+
+const isSidebarOpen = ref(false)
+
+const initials = computed(() => {
+  return props.userName
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+})
+
+const toggleSidebar = () => {
+  isSidebarOpen.value = !isSidebarOpen.value
+}
+
+const closeSidebar = () => {
+  isSidebarOpen.value = false
+}
+
+const handleMenuClick = () => {
+  closeSidebar()
+}
+
+const handleLogout = () => {
+  emit('logout')
+  closeSidebar()
+}
+
+const handleResize = () => {
+  if (typeof window === 'undefined') return
+  if (window.innerWidth >= 820) {
+    isSidebarOpen.value = false
+  }
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') return
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('resize', handleResize)
+})
+
+const progressStyle = computed(() => {
+  const progress = Math.min(Math.max(props.stats.progress ?? 0.65, 0), 1)
+  const degrees = `${Math.round(progress * 360)}deg`
+  return {
+    '--progress-deg': degrees,
+    '--chart-color': props.stats.accent || props.accentColor
+  }
+})
+</script>
+
+<style scoped>
+.dashboard {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5f7ff 0%, #eef1ff 100%);
+  color: #1b2142;
+  position: relative;
+}
+
+.dashboard--sidebar-open {
+  overflow: hidden;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, #0f1c3f 0%, #122358 60%, #101a43 100%);
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  color: #ecf1ff;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform 0.3s ease;
+  position: relative;
+  z-index: 40;
+}
+
+.sidebar__close {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar__close span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 18px;
+  background: linear-gradient(135deg, var(--accent-color), rgba(99, 140, 255, 0.85));
+  color: #fff;
+}
+
+.brand-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-name {
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+
+.brand-tag {
+  font-size: 12px;
+  color: rgba(236, 241, 255, 0.65);
+}
+
+.sidebar__role {
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(15, 28, 63, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  width: fit-content;
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.02);
+  transition: background 0.2s ease, transform 0.2s ease;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.menu-item.active {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.menu-item__bullet {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.menu-item.active .menu-item__bullet {
+  background: #fff;
+}
+
+.menu-item__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.menu-item__label {
+  font-weight: 500;
+}
+
+.menu-item__helper {
+  font-size: 12px;
+  color: rgba(236, 241, 255, 0.6);
+}
+
+.sidebar__support {
+  margin-top: auto;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 16px;
+  border-radius: 16px;
+  font-size: 13px;
+}
+
+.sidebar__support a {
+  margin-top: 6px;
+  display: inline-block;
+  color: #9cb4ff;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar__logout {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(7, 15, 36, 0.45);
+  color: #ecf1ff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  align-self: flex-start;
+}
+
+.sidebar__logout:hover {
+  background: rgba(7, 15, 36, 0.65);
+  transform: translateY(-1px);
+}
+
+.sidebar__logout-icon {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.15);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 16, 35, 0.55);
+  z-index: 30;
+}
+
+.dashboard__main {
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  position: relative;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.dashboard__greeting {
+  font-size: 15px;
+  color: #6a7190;
+  margin-bottom: 4px;
+}
+
+.sidebar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  padding: 6px 4px;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.sidebar-toggle span {
+  display: block;
+  width: 24px;
+  height: 3px;
+  border-radius: 999px;
+  background: #1b2142;
+}
+
+.dashboard__header h1 {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.dashboard__profile {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.profile-name {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.profile-label {
+  font-size: 12px;
+  color: #7f87aa;
+  letter-spacing: 0.8px;
+}
+
+.profile-value {
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.profile-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent-color), rgba(95, 132, 250, 0.95));
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.dashboard__slot {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.summary-card {
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 24px;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  box-shadow:
+    0 18px 35px rgba(21, 36, 82, 0.06),
+    0 3px 8px rgba(27, 33, 66, 0.04);
+}
+
+.summary-card__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, var(--card-color), rgba(158, 184, 255, 0.9));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.summary-card__title {
+  font-size: 14px;
+  color: #767ca0;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.summary-card__value {
+  font-size: 26px;
+  font-weight: 600;
+  color: #161c3f;
+}
+
+.summary-card__meta {
+  font-size: 13px;
+  color: #6f7592;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.recent-card,
+.stats-card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px 26px;
+  box-shadow:
+    0 24px 45px rgba(21, 36, 82, 0.08),
+    0 4px 12px rgba(27, 33, 66, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-header h2 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.card-header p {
+  font-size: 13px;
+  color: #7f87aa;
+}
+
+.card-header button {
+  border: none;
+  background: rgba(31, 60, 136, 0.08);
+  color: var(--accent-color);
+  font-weight: 600;
+  padding: 10px 16px;
+  border-radius: 14px;
+  cursor: pointer;
+}
+
+.recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.recent-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed rgba(23, 31, 74, 0.1);
+}
+
+.recent-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.recent-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.recent-item__name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.recent-item__desc {
+  font-size: 13px;
+  color: #8087a3;
+}
+
+.recent-item__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.recent-item__amount {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge--success {
+  background: rgba(54, 211, 153, 0.15);
+  color: #1d9c6c;
+}
+
+.badge--warning {
+  background: rgba(255, 193, 7, 0.18);
+  color: #b88a00;
+}
+
+.badge--info {
+  background: rgba(78, 125, 255, 0.18);
+  color: #335ed7;
+}
+
+.badge--neutral {
+  background: rgba(127, 135, 170, 0.15);
+  color: #6d7394;
+}
+
+.stats-card__period {
+  font-size: 13px;
+  color: #7f87aa;
+}
+
+.stats-card__body {
+  display: flex;
+  gap: 24px;
+}
+
+.stats-card__chart {
+  --progress-deg: 240deg;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: conic-gradient(var(--chart-color) 0 var(--progress-deg), rgba(240, 243, 255, 0.8) var(--progress-deg) 360deg);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.stats-card__chart-inner {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  box-shadow: inset 0 2px 6px rgba(31, 60, 136, 0.08);
+}
+
+.chart-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.chart-label {
+  font-size: 12px;
+  color: #7f87aa;
+  text-align: center;
+}
+
+.stats-card__list {
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stats-card__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.stats-card__list strong {
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quick-actions h3 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.quick-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.quick-action {
+  background: rgba(31, 60, 136, 0.06);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quick-action h4 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.quick-action p {
+  font-size: 12px;
+  color: #6b7395;
+}
+
+.stats-card__footer {
+  font-size: 12px;
+  color: #8b92b4;
+  text-align: right;
+}
+
+@media (max-width: 1080px) {
+  .dashboard {
+    grid-template-columns: 240px 1fr;
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-card__body {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .stats-card__list {
+    width: 100%;
+  }
+}
+
+@media (max-width: 820px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+    position: relative;
+  }
+
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(78vw, 320px);
+    max-width: 340px;
+    height: 100vh;
+    transform: translateX(-100%);
+    box-shadow: 18px 0 35px rgba(12, 18, 38, 0.35);
+    padding: 28px 24px 32px;
+    gap: 28px;
+    border-right: none;
+  }
+
+  .dashboard--sidebar-open .sidebar {
+    transform: translateX(0);
+  }
+
+  .sidebar__close {
+    display: inline-flex;
+  }
+
+  .sidebar__footer {
+    gap: 12px;
+  }
+
+  .sidebar__support {
+    background: rgba(255, 255, 255, 0.04);
+    padding: 14px;
+  }
+
+  .dashboard__main {
+    padding: 28px 20px 36px;
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 18px;
+    position: relative;
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 640px) {
+  .cards-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__header h1 {
+    font-size: 24px;
+  }
+
+  .profile-avatar {
+    width: 42px;
+    height: 42px;
+  }
+
+  .recent-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .recent-item__meta {
+    align-items: center;
+    flex-direction: row;
+    gap: 12px;
+  }
+
+  .stats-card__body {
+    align-items: stretch;
+  }
+
+  .quick-actions__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .dashboard__main {
+    padding: 24px 16px 32px;
+  }
+
+  .summary-card {
+    padding: 20px;
+    border-radius: 18px;
+  }
+
+  .recent-card,
+  .stats-card {
+    padding: 20px;
+    border-radius: 20px;
+  }
+
+  .card-header h2 {
+    font-size: 18px;
+  }
+
+  .stats-card__chart {
+    width: 180px;
+    height: 180px;
+  }
+}
+</style>

--- a/src/components/EmployeeProfilePanel.vue
+++ b/src/components/EmployeeProfilePanel.vue
@@ -27,6 +27,10 @@
             <dd>{{ employee.email }}</dd>
           </div>
           <div>
+            <dt>Kata Sandi Portal</dt>
+            <dd class="profile-panel__password">{{ employee.password }}</dd>
+          </div>
+          <div>
             <dt>Departemen</dt>
             <dd>{{ employee.department }}</dd>
           </div>
@@ -190,6 +194,12 @@ const formatDate = (value) => {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+}
+
+.profile-panel__password {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  letter-spacing: 0.4px;
+  color: #1f3c88;
 }
 
 .profile-panel__header h2 {

--- a/src/components/EmployeeProfilePanel.vue
+++ b/src/components/EmployeeProfilePanel.vue
@@ -1,0 +1,337 @@
+<template>
+  <section class="profile-panel" v-if="employee">
+    <header class="profile-panel__header">
+      <div>
+        <h2>Biodata Pegawai</h2>
+        <p>Perbarui informasi kontak, rekening bank, dan field tambahan yang diminta perusahaan.</p>
+      </div>
+      <button type="button" class="button button--primary" @click="handleSubmit" :disabled="isSaving">
+        {{ isSaving ? 'Menyimpan…' : 'Simpan perubahan' }}
+      </button>
+    </header>
+
+    <div class="profile-panel__grid">
+      <article class="profile-card">
+        <h3>Informasi Tetap</h3>
+        <dl>
+          <div>
+            <dt>Nomor Pegawai</dt>
+            <dd>{{ employee.employeeNumber }}</dd>
+          </div>
+          <div>
+            <dt>Nama Lengkap</dt>
+            <dd>{{ employee.name }}</dd>
+          </div>
+          <div>
+            <dt>Email Perusahaan</dt>
+            <dd>{{ employee.email }}</dd>
+          </div>
+          <div>
+            <dt>Departemen</dt>
+            <dd>{{ employee.department }}</dd>
+          </div>
+          <div>
+            <dt>Jabatan</dt>
+            <dd>{{ employee.position }}</dd>
+          </div>
+          <div>
+            <dt>Tanggal Bergabung</dt>
+            <dd>{{ formatDate(employee.joinDate) }}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <form class="profile-card" @submit.prevent="handleSubmit">
+        <h3>Kontak & Rekening</h3>
+        <div class="form-grid">
+          <label class="form-field">
+            <span>Nomor Telepon</span>
+            <input v-model="formState.phone" type="tel" placeholder="0812-xxxx-xxxx" required />
+          </label>
+          <label class="form-field">
+            <span>Alamat Domisili</span>
+            <textarea v-model="formState.address" rows="3" placeholder="Tulis alamat lengkap" required></textarea>
+          </label>
+          <label class="form-field">
+            <span>Nama Bank</span>
+            <input v-model="formState.bankName" type="text" placeholder="Nama bank" />
+          </label>
+          <label class="form-field">
+            <span>Nomor Rekening</span>
+            <input v-model="formState.bankAccount" type="text" placeholder="Nomor rekening" />
+          </label>
+          <label class="form-field">
+            <span>Nama Kontak Darurat</span>
+            <input v-model="formState.emergencyContactName" type="text" placeholder="Nama lengkap" />
+          </label>
+          <label class="form-field">
+            <span>Nomor Kontak Darurat</span>
+            <input v-model="formState.emergencyContactPhone" type="tel" placeholder="0812-xxxx-xxxx" />
+          </label>
+        </div>
+      </form>
+
+      <form v-if="customFields.length" class="profile-card" @submit.prevent="handleSubmit">
+        <h3>Field Tambahan</h3>
+        <div class="form-grid">
+          <label v-for="field in customFields" :key="field.id" class="form-field">
+            <span>{{ field.label }}</span>
+            <input v-model="customValues[field.key]" type="text" :placeholder="`Isi ${field.label.toLowerCase()}`" />
+          </label>
+        </div>
+      </form>
+    </div>
+
+    <transition name="fade">
+      <p v-if="feedback" class="profile-panel__feedback">{{ feedback }}</p>
+    </transition>
+  </section>
+
+  <section v-else class="profile-panel profile-panel--empty">
+    <h2>Data pegawai tidak ditemukan</h2>
+    <p>Silakan hubungi administrator untuk memastikan email Anda terdaftar.</p>
+  </section>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch } from 'vue'
+
+import { useEmployeeStore } from '../utils/employeeStore'
+
+const props = defineProps({
+  email: { type: String, required: true }
+})
+
+const { employees, customFields, updateEmployee, getEmployeeByEmail } = useEmployeeStore()
+
+const employee = computed(() => {
+  if (!props.email) return null
+  return getEmployeeByEmail(props.email) || null
+})
+
+const formState = reactive({
+  phone: '',
+  address: '',
+  bankName: '',
+  bankAccount: '',
+  emergencyContactName: '',
+  emergencyContactPhone: ''
+})
+
+const customValues = reactive({})
+const feedback = ref('')
+const isSaving = ref(false)
+
+const syncForm = () => {
+  if (!employee.value) return
+  formState.phone = employee.value.phone || ''
+  formState.address = employee.value.address || ''
+  formState.bankName = employee.value.bankName || ''
+  formState.bankAccount = employee.value.bankAccount || ''
+  formState.emergencyContactName = employee.value.emergencyContactName || ''
+  formState.emergencyContactPhone = employee.value.emergencyContactPhone || ''
+
+  Object.keys(customValues).forEach((key) => delete customValues[key])
+  customFields.value.forEach((field) => {
+    customValues[field.key] = employee.value.customValues?.[field.key] || ''
+  })
+}
+
+watch(employee, syncForm, { immediate: true })
+watch(customFields, syncForm, { deep: true })
+
+const handleSubmit = async () => {
+  if (!employee.value) return
+  if (isSaving.value) return
+
+  isSaving.value = true
+  feedback.value = ''
+
+  updateEmployee(employee.value.id, {
+    ...formState,
+    customValues: { ...customValues }
+  })
+
+  setTimeout(() => {
+    feedback.value = 'Perubahan berhasil disimpan.'
+    isSaving.value = false
+    setTimeout(() => {
+      feedback.value = ''
+    }, 2500)
+  }, 300)
+}
+
+const formatDate = (value) => {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric'
+  })
+}
+</script>
+
+<style scoped>
+.profile-panel {
+  background: #ffffff;
+  border-radius: 26px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 20px 45px rgba(15, 28, 63, 0.08);
+}
+
+.profile-panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.profile-panel__header h2 {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.profile-panel__header p {
+  color: #6a7190;
+  font-size: 14px;
+}
+
+.profile-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.profile-card {
+  background: rgba(248, 250, 255, 0.7);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  border-radius: 22px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.profile-card h3 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin: 0;
+}
+
+dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px dashed rgba(31, 60, 136, 0.12);
+  padding-bottom: 8px;
+}
+
+ dt {
+  font-size: 13px;
+  color: #6a7190;
+}
+
+ dd {
+  margin: 0;
+  font-weight: 600;
+  color: #1b2142;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-field span {
+  font-size: 13px;
+  color: #1b2142;
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field textarea {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  background: #ffffff;
+  font-size: 14px;
+  color: #1b2142;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 14px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #0b2c59 0%, #154e8a 100%);
+  color: #ffffff;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.profile-panel__feedback {
+  font-size: 13px;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.profile-panel--empty {
+  align-items: center;
+  text-align: center;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 768px) {
+  .profile-panel__header {
+    align-items: stretch;
+  }
+
+  .profile-panel__header button {
+    width: 100%;
+  }
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,8 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.use(router)
+app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,51 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import LoginView from '../views/LoginView.vue'
+import AdminDashboard from '../views/AdminDashboard.vue'
+import EmployeeDashboard from '../views/EmployeeDashboard.vue'
+import { ROLE_ROUTES, getStoredUser } from '../utils/auth'
+
+const routes = [
+  { path: '/', redirect: '/login' },
+  { path: '/login', name: 'login', component: LoginView },
+  {
+    path: '/admin',
+    name: 'admin-dashboard',
+    component: AdminDashboard,
+    meta: { requiresAuth: true, role: 'admin' }
+  },
+  {
+    path: '/pegawai',
+    name: 'employee-dashboard',
+    component: EmployeeDashboard,
+    meta: { requiresAuth: true, role: 'pegawai' }
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+router.beforeEach((to, from, next) => {
+  const user = getStoredUser()
+
+  if (to.meta.requiresAuth && !user) {
+    next({ name: 'login', query: { redirect: to.fullPath } })
+    return
+  }
+
+  if (to.meta.role && user && to.meta.role !== user.role) {
+    next({ path: ROLE_ROUTES[user.role] || '/login' })
+    return
+  }
+
+  if (to.name === 'login' && user) {
+    next({ path: ROLE_ROUTES[user.role] || '/admin' })
+    return
+  }
+
+  next()
+})
+
+export default router

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,29 @@
+const STORAGE_KEY = 'amk-portal-auth'
+
+export const ROLE_ROUTES = {
+  admin: '/admin',
+  pegawai: '/pegawai'
+}
+
+export function storeUserSession(user) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+}
+
+export function getStoredUser() {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    console.warn('Gagal mengurai data sesi pengguna', error)
+    window.localStorage.removeItem(STORAGE_KEY)
+    return null
+  }
+}
+
+export function clearUserSession() {
+  if (typeof window === 'undefined') return
+  window.localStorage.removeItem(STORAGE_KEY)
+}

--- a/src/utils/employeeStore.js
+++ b/src/utils/employeeStore.js
@@ -243,6 +243,24 @@ export const useEmployeeStore = () => {
     return field
   }
 
+  const removeCustomField = (id) => {
+    const field = customFields.value.find((item) => item.id === id)
+    if (!field) return
+
+    customFields.value = customFields.value.filter((item) => item.id !== id)
+
+    employees.value = employees.value.map((record) => {
+      if (!record.customValues) return { ...record }
+      const { [field.key]: _removed, ...rest } = record.customValues
+      return {
+        ...record,
+        customValues: { ...rest }
+      }
+    })
+
+    return field
+  }
+
   const upsertCustomValue = (employeeId, fieldKey, value) => {
     updateEmployee(employeeId, {
       customValues: {
@@ -263,6 +281,7 @@ export const useEmployeeStore = () => {
     updateEmployee,
     removeEmployee,
     addCustomField,
+    removeCustomField,
     upsertCustomValue,
     getEmployeeByEmail
   }

--- a/src/utils/employeeStore.js
+++ b/src/utils/employeeStore.js
@@ -1,0 +1,269 @@
+import { computed, ref, watch } from 'vue'
+
+const EMPLOYEE_STORAGE_KEY = 'amk-portal-employees'
+const FIELD_STORAGE_KEY = 'amk-portal-employee-fields'
+
+const defaultCustomFields = [
+  { id: 'field-sertifikasi', key: 'sertifikasi', label: 'Sertifikasi Profesional' }
+]
+
+const defaultEmployees = [
+  {
+    id: 'emp-001',
+    employeeNumber: 'AMK-001',
+    name: 'Raisa Dewi',
+    email: 'pegawai@amk.com',
+    password: 'pegawai123',
+    department: 'Marketing',
+    position: 'Spesialis Marketing',
+    phone: '0812-3456-7890',
+    address: 'Jl. Melati No. 5, Jakarta',
+    joinDate: '2021-01-12',
+    bankName: 'BCA',
+    bankAccount: '1234567890',
+    emergencyContactName: 'Dinda Lestari',
+    emergencyContactPhone: '0813-9876-5432',
+    dateOfBirth: '1995-06-21',
+    customValues: {
+      sertifikasi: 'Google Analytics Individual Qualification'
+    }
+  },
+  {
+    id: 'emp-002',
+    employeeNumber: 'AMK-002',
+    name: 'Hafidz Maulana',
+    email: 'hafidz@amk.com',
+    password: 'hafidz123',
+    department: 'Finance',
+    position: 'Analis Keuangan',
+    phone: '0817-2233-4455',
+    address: 'Jl. Kenanga No. 12, Bandung',
+    joinDate: '2020-08-03',
+    bankName: 'Mandiri',
+    bankAccount: '9876543210',
+    emergencyContactName: 'Rina Maulana',
+    emergencyContactPhone: '0812-6655-4321',
+    dateOfBirth: '1992-02-14',
+    customValues: {
+      sertifikasi: 'Brevet Pajak AB'
+    }
+  },
+  {
+    id: 'emp-003',
+    employeeNumber: 'AMK-003',
+    name: 'Putri Anggraini',
+    email: 'putri@amk.com',
+    password: 'putri123',
+    department: 'Human Capital',
+    position: 'HR Generalist',
+    phone: '0813-4455-6677',
+    address: 'Jl. Cemara No. 8, Surabaya',
+    joinDate: '2022-05-18',
+    bankName: 'BNI',
+    bankAccount: '4567890123',
+    emergencyContactName: 'Adi Santoso',
+    emergencyContactPhone: '0813-2244-6688',
+    dateOfBirth: '1994-11-02',
+    customValues: {
+      sertifikasi: 'Certified Human Resource Professional'
+    }
+  }
+]
+
+const employees = ref([])
+const customFields = ref([])
+let hydrated = false
+
+const ensureCustomValues = (record) => {
+  const values = { ...(record.customValues || {}) }
+  customFields.value.forEach((field) => {
+    if (typeof values[field.key] === 'undefined') {
+      values[field.key] = ''
+    }
+  })
+  return { ...record, customValues: values }
+}
+
+const persistEmployees = (data) => {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(EMPLOYEE_STORAGE_KEY, JSON.stringify(data))
+}
+
+const persistFields = (data) => {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(FIELD_STORAGE_KEY, JSON.stringify(data))
+}
+
+const hydrate = () => {
+  if (hydrated) return
+
+  if (typeof window === 'undefined') {
+    customFields.value = [...defaultCustomFields]
+    employees.value = defaultEmployees.map((item) => ({
+      ...item,
+      customValues: { ...item.customValues }
+    }))
+    hydrated = true
+    return
+  }
+
+  try {
+    const storedFields = window.localStorage.getItem(FIELD_STORAGE_KEY)
+    if (storedFields) {
+      customFields.value = JSON.parse(storedFields)
+    } else {
+      customFields.value = [...defaultCustomFields]
+      persistFields(customFields.value)
+    }
+  } catch (error) {
+    console.warn('Gagal membaca data field kustom, menggunakan nilai bawaan', error)
+    customFields.value = [...defaultCustomFields]
+  }
+
+  try {
+    const storedEmployees = window.localStorage.getItem(EMPLOYEE_STORAGE_KEY)
+    if (storedEmployees) {
+      employees.value = JSON.parse(storedEmployees)
+    } else {
+      employees.value = defaultEmployees.map((item) => ({
+        ...item,
+        customValues: { ...item.customValues }
+      }))
+      persistEmployees(employees.value)
+    }
+  } catch (error) {
+    console.warn('Gagal membaca data pegawai, menggunakan nilai bawaan', error)
+    employees.value = defaultEmployees.map((item) => ({
+      ...item,
+      customValues: { ...item.customValues }
+    }))
+  }
+
+  employees.value = employees.value.map((record) => ensureCustomValues(record))
+
+  hydrated = true
+
+  watch(
+    employees,
+    (value) => {
+      persistEmployees(value)
+    },
+    { deep: true }
+  )
+
+  watch(
+    customFields,
+    (value) => {
+      persistFields(value)
+      employees.value = employees.value.map((record) => ensureCustomValues(record))
+    },
+    { deep: true }
+  )
+}
+
+const slugify = (text) =>
+  text
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+const generateId = (prefix) => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export const useEmployeeStore = () => {
+  hydrate()
+
+  const sortedEmployees = computed(() => {
+    return [...employees.value].sort((a, b) => a.name.localeCompare(b.name))
+  })
+
+  const addEmployee = (payload) => {
+    const id = payload.id || generateId('emp')
+    const base = ensureCustomValues({
+      ...payload,
+      id,
+      customValues: { ...(payload.customValues || {}) }
+    })
+    employees.value = [...employees.value, base]
+    return id
+  }
+
+  const updateEmployee = (id, updates) => {
+    employees.value = employees.value.map((employee) => {
+      if (employee.id !== id) return employee
+      return ensureCustomValues({
+        ...employee,
+        ...updates,
+        customValues: {
+          ...employee.customValues,
+          ...(updates.customValues || {})
+        }
+      })
+    })
+  }
+
+  const removeEmployee = (id) => {
+    employees.value = employees.value.filter((employee) => employee.id !== id)
+  }
+
+  const addCustomField = (label) => {
+    const trimmed = label.trim()
+    if (!trimmed) return null
+
+    let key = slugify(trimmed)
+    if (!key) {
+      key = `field-${customFields.value.length + 1}`
+    }
+
+    let attempt = 1
+    const existingKeys = new Set(customFields.value.map((field) => field.key))
+    while (existingKeys.has(key)) {
+      attempt += 1
+      key = `${slugify(trimmed)}-${attempt}`
+    }
+
+    const field = {
+      id: generateId('field'),
+      key,
+      label: trimmed
+    }
+
+    customFields.value = [...customFields.value, field]
+    employees.value = employees.value.map((record) => ({
+      ...record,
+      customValues: { ...record.customValues, [key]: '' }
+    }))
+
+    return field
+  }
+
+  const upsertCustomValue = (employeeId, fieldKey, value) => {
+    updateEmployee(employeeId, {
+      customValues: {
+        [fieldKey]: value
+      }
+    })
+  }
+
+  const getEmployeeByEmail = (email) => {
+    return employees.value.find((employee) => employee.email.toLowerCase() === email.toLowerCase())
+  }
+
+  return {
+    employees,
+    customFields,
+    sortedEmployees,
+    addEmployee,
+    updateEmployee,
+    removeEmployee,
+    addCustomField,
+    upsertCustomValue,
+    getEmployeeByEmail
+  }
+}

--- a/src/views/AdminDashboard.vue
+++ b/src/views/AdminDashboard.vue
@@ -1,0 +1,189 @@
+<template>
+  <DashboardLayout
+    :user-name="userName"
+    role="Administrator"
+    :menu-items="menuItems"
+    :summary-cards="summaryCards"
+    :recent-title="recentTitle"
+    :recent-subtitle="recentSubtitle"
+    :recent-items="recentItems"
+    :stats="stats"
+    :quick-actions="quickActions"
+    quick-actions-title="Aksi cepat untuk admin"
+    accent-color="#1f3c88"
+    greeting="Semangat mengelola tim hari ini!"
+    @logout="handleLogout"
+  >
+    <template #content>
+      <AdminEmployeeManager />
+    </template>
+  </DashboardLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+import DashboardLayout from '../components/DashboardLayout.vue'
+import AdminEmployeeManager from '../components/AdminEmployeeManager.vue'
+import { clearUserSession, getStoredUser } from '../utils/auth'
+import { useEmployeeStore } from '../utils/employeeStore'
+
+const router = useRouter()
+
+const sessionUser = getStoredUser()
+
+if (!sessionUser || sessionUser.role !== 'admin') {
+  router.replace({ name: 'login' })
+}
+
+const userName = sessionUser?.name ?? 'Naufal Pratama'
+
+const handleLogout = () => {
+  clearUserSession()
+  router.push('/login')
+}
+
+const menuItems = [
+  { label: 'Beranda', helper: 'Ringkasan data pegawai' },
+  { label: 'Data Pegawai', helper: 'Kelola biodata & akses' },
+  { label: 'Field Tambahan', helper: 'Atur kebutuhan informasi' }
+]
+
+const { employees, customFields } = useEmployeeStore()
+
+const completionKeys = ['phone', 'address', 'bankName', 'bankAccount', 'emergencyContactName', 'emergencyContactPhone']
+
+const averageCompletion = computed(() => {
+  if (!employees.value.length) return 0
+  const totalFields = completionKeys.length + customFields.value.length
+  if (!totalFields) return 1
+
+  let filled = 0
+  employees.value.forEach((employee) => {
+    completionKeys.forEach((key) => {
+      if (employee[key]) filled += 1
+    })
+    customFields.value.forEach((field) => {
+      if (employee.customValues?.[field.key]) filled += 1
+    })
+  })
+
+  return Math.min(filled / (totalFields * employees.value.length), 1)
+})
+
+const summaryCards = computed(() => [
+  {
+    title: 'Total Pegawai',
+    value: `${employees.value.length} Pegawai`,
+    meta: 'Seluruh data tersimpan lokal',
+    icon: '👥',
+    accent: '#4e7dff'
+  },
+  {
+    title: 'Field Biodata',
+    value: `${completionKeys.length + customFields.value.length} Field`,
+    meta: `${customFields.value.length} field kustom aktif`,
+    icon: '🗂️',
+    accent: '#5bc4bf'
+  },
+  {
+    title: 'Kelengkapan Rata-rata',
+    value: `${Math.round(averageCompletion.value * 100)}%`,
+    meta: 'Progress update oleh pegawai',
+    icon: '✅',
+    accent: '#ffba5a'
+  }
+])
+
+const describeCompletion = (employee) => {
+  const total = completionKeys.length + customFields.value.length
+  if (!total) {
+    return { label: 'Lengkap', tone: 'success', amount: '100%' }
+  }
+  let filled = 0
+  completionKeys.forEach((key) => {
+    if (employee[key]) filled += 1
+  })
+  customFields.value.forEach((field) => {
+    if (employee.customValues?.[field.key]) filled += 1
+  })
+  const percent = Math.round((filled / total) * 100)
+  if (percent === 100) {
+    return { label: 'Lengkap', tone: 'success', amount: '100%' }
+  }
+  if (percent >= 60) {
+    return { label: 'Hampir lengkap', tone: 'info', amount: `${percent}%` }
+  }
+  return { label: 'Perlu data', tone: 'warning', amount: `${percent}%` }
+}
+
+const recentItems = computed(() => {
+  return [...employees.value]
+    .sort((a, b) => new Date(b.joinDate) - new Date(a.joinDate))
+    .slice(0, 3)
+    .map((employee) => {
+      const status = describeCompletion(employee)
+      return {
+        id: employee.id,
+        name: employee.name,
+        description: `${employee.department} • Bergabung ${formatDate(employee.joinDate)}`,
+        amount: status.amount,
+        status
+      }
+    })
+})
+
+const departmentStats = computed(() => {
+  const counts = new Map()
+  employees.value.forEach((employee) => {
+    const key = employee.department || 'Lainnya'
+    counts.set(key, (counts.get(key) || 0) + 1)
+  })
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([label, value]) => ({ label, value: `${value} pegawai` }))
+})
+
+const stats = computed(() => ({
+  title: 'Ringkasan biodata',
+  subtitle: 'Monitoring kelengkapan data pegawai',
+  period: new Date().toLocaleDateString('id-ID', { month: 'long', year: 'numeric' }),
+  total: `${Math.round(averageCompletion.value * 100)}%`,
+  totalLabel: 'Rata-rata terisi',
+  progress: averageCompletion.value,
+  accent: '#4e7dff',
+  items: departmentStats.value,
+  footer: `Terakhir diperbarui ${new Date().toLocaleDateString('id-ID')}`
+}))
+
+const quickActions = computed(() => [
+  {
+    label: 'Tambah field biodata',
+    description: 'Butuh informasi baru? Tambahkan field kustom dan terapkan ke semua pegawai.'
+  },
+  {
+    label: 'Review kelengkapan',
+    description: 'Pantau pegawai yang masih perlu melengkapi biodata mereka.'
+  },
+  {
+    label: 'Perbarui kredensial',
+    description: 'Kelola email dan kata sandi demo langsung dari daftar pegawai.'
+  }
+])
+
+const recentTitle = 'Aktivitas data pegawai'
+const recentSubtitle = 'Pegawai terbaru dan status kelengkapan biodata mereka.'
+
+function formatDate(value) {
+  if (!value) return '–'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('id-ID', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric'
+  })
+}
+</script>

--- a/src/views/AdminDashboard.vue
+++ b/src/views/AdminDashboard.vue
@@ -12,16 +12,18 @@
     quick-actions-title="Aksi cepat untuk admin"
     accent-color="#1f3c88"
     greeting="Semangat mengelola tim hari ini!"
+    overview-key="overview"
+    v-model:active-menu-key="activeMenu"
     @logout="handleLogout"
   >
-    <template #content>
+    <template #pegawai>
       <AdminEmployeeManager />
     </template>
   </DashboardLayout>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import DashboardLayout from '../components/DashboardLayout.vue'
@@ -44,10 +46,11 @@ const handleLogout = () => {
   router.push('/login')
 }
 
+const activeMenu = ref('overview')
+
 const menuItems = [
-  { label: 'Beranda', helper: 'Ringkasan data pegawai' },
-  { label: 'Data Pegawai', helper: 'Kelola biodata & akses' },
-  { label: 'Field Tambahan', helper: 'Atur kebutuhan informasi' }
+  { key: 'overview', label: 'Beranda', helper: 'Ringkasan data pegawai' },
+  { key: 'pegawai', label: 'Data Pegawai', helper: 'Kelola biodata & akses' }
 ]
 
 const { employees, customFields } = useEmployeeStore()

--- a/src/views/EmployeeDashboard.vue
+++ b/src/views/EmployeeDashboard.vue
@@ -1,0 +1,201 @@
+<template>
+  <DashboardLayout
+    :user-name="userName"
+    role="Pegawai"
+    :menu-items="menuItems"
+    :summary-cards="summaryCards"
+    :recent-title="recentTitle"
+    :recent-subtitle="recentSubtitle"
+    :recent-items="recentItems"
+    :stats="stats"
+    :quick-actions="quickActions"
+    quick-actions-title="Butuh melakukan sesuatu?"
+    accent-color="#1f3c88"
+    greeting="Hai, berikut ringkasan biodata Anda!"
+    @logout="handleLogout"
+  >
+    <template #content>
+      <EmployeeProfilePanel :email="sessionUser?.email || ''" />
+    </template>
+  </DashboardLayout>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+import DashboardLayout from '../components/DashboardLayout.vue'
+import EmployeeProfilePanel from '../components/EmployeeProfilePanel.vue'
+import { clearUserSession, getStoredUser } from '../utils/auth'
+import { useEmployeeStore } from '../utils/employeeStore'
+
+const router = useRouter()
+
+const sessionUser = getStoredUser()
+
+if (!sessionUser || sessionUser.role !== 'pegawai') {
+  router.replace({ name: 'login' })
+}
+
+const userName = sessionUser?.name ?? 'Anisa Putri'
+
+const handleLogout = () => {
+  clearUserSession()
+  router.push('/login')
+}
+
+const menuItems = [
+  { label: 'Beranda', helper: 'Ringkasan biodata' },
+  { label: 'Biodata', helper: 'Perbarui informasi Anda' },
+  { label: 'Field Tambahan', helper: 'Lengkapi permintaan HR' }
+]
+
+const { customFields, getEmployeeByEmail } = useEmployeeStore()
+
+const completionKeys = ['phone', 'address', 'bankName', 'bankAccount', 'emergencyContactName', 'emergencyContactPhone']
+const fieldLabels = {
+  phone: 'Nomor Telepon',
+  address: 'Alamat Domisili',
+  bankName: 'Nama Bank',
+  bankAccount: 'Nomor Rekening',
+  emergencyContactName: 'Nama Kontak Darurat',
+  emergencyContactPhone: 'Nomor Kontak Darurat'
+}
+
+const employeeRecord = computed(() => {
+  if (!sessionUser?.email) return null
+  return getEmployeeByEmail(sessionUser.email) || null
+})
+
+const completion = computed(() => {
+  if (!employeeRecord.value) return 0
+  const totalFields = completionKeys.length + customFields.value.length
+  if (!totalFields) return 1
+  let filled = 0
+  completionKeys.forEach((key) => {
+    if (employeeRecord.value?.[key]) filled += 1
+  })
+  customFields.value.forEach((field) => {
+    if (employeeRecord.value?.customValues?.[field.key]) filled += 1
+  })
+  return Math.min(filled / totalFields, 1)
+})
+
+const summaryCards = computed(() => {
+  const employee = employeeRecord.value
+  return [
+    {
+      title: 'Nomor Pegawai',
+      value: employee?.employeeNumber || '—',
+      meta: employee?.department || 'Belum ada departemen',
+      icon: '🆔',
+      accent: '#4e7dff'
+    },
+    {
+      title: 'Kelengkapan Biodata',
+      value: `${Math.round(completion.value * 100)}%`,
+      meta: completion.value === 1 ? 'Semua informasi telah lengkap' : 'Masih ada data yang perlu diisi',
+      icon: '📋',
+      accent: '#5bc4bf'
+    },
+    {
+      title: 'Kontak Darurat',
+      value: employee?.emergencyContactName || 'Belum diisi',
+      meta: employee?.emergencyContactPhone || 'Isi kontak untuk keadaan darurat',
+      icon: '☎️',
+      accent: '#ffba5a'
+    }
+  ]
+})
+
+const pendingFields = computed(() => {
+  if (!employeeRecord.value) return []
+  const missing = []
+  completionKeys.forEach((key) => {
+    if (!employeeRecord.value?.[key]) {
+      missing.push(fieldLabels[key])
+    }
+  })
+  customFields.value.forEach((field) => {
+    if (!employeeRecord.value?.customValues?.[field.key]) {
+      missing.push(field.label)
+    }
+  })
+  return missing.slice(0, 3)
+})
+
+const recentItems = computed(() => {
+  if (!employeeRecord.value) return []
+  const highlights = [
+    {
+      label: 'Alamat Domisili',
+      value: employeeRecord.value.address,
+      helper: 'Pastikan alamat sesuai untuk pengiriman dokumen'
+    },
+    {
+      label: 'Rekening Bank',
+      value: employeeRecord.value.bankAccount,
+      helper: 'Digunakan untuk pencairan gaji'
+    },
+    {
+      label: 'Sertifikasi',
+      value: customFields.value.length
+        ? employeeRecord.value.customValues?.[customFields.value[0].key]
+        : null,
+      helper: customFields.value.length ? customFields.value[0].label : 'Belum ada field tambahan'
+    }
+  ]
+
+  return highlights.map((item, index) => ({
+    id: index,
+    name: item.label,
+    description: item.helper,
+    amount: item.value
+      ? 'Terisi'
+      : item.helper === 'Belum ada field tambahan'
+        ? 'Tidak diperlukan'
+        : 'Belum diisi',
+    status: item.value
+      ? { label: 'Lengkap', tone: 'success' }
+      : item.helper === 'Belum ada field tambahan'
+        ? { label: 'Tidak diperlukan', tone: 'neutral' }
+        : { label: 'Perlu diisi', tone: 'warning' }
+  }))
+})
+
+const stats = computed(() => {
+  const percent = Math.round(completion.value * 100)
+  const missing = pendingFields.value
+  const items = missing.length
+    ? missing.map((label) => ({ label, value: 'Perlu diisi' }))
+    : [{ label: 'Semua data', value: '✅ Lengkap' }]
+
+  return {
+    title: 'Status biodata',
+    subtitle: 'Pastikan semua informasi wajib telah diisi',
+    period: new Date().toLocaleDateString('id-ID', { month: 'long', year: 'numeric' }),
+    total: `${percent}%`,
+    totalLabel: missing.length ? `${missing.length} field belum terisi` : 'Semua field telah lengkap',
+    progress: completion.value,
+    accent: '#4e7dff',
+    items,
+    footer: missing.length
+      ? 'Lengkapi data yang masih kosong untuk mempercepat administrasi.'
+      : 'Terima kasih! Semua biodata sudah lengkap.'
+  }
+})
+
+const quickActions = computed(() => [
+  {
+    label: 'Perbarui biodata',
+    description: 'Isi atau revisi informasi kontak Anda di panel biodata.'
+  },
+  {
+    label: 'Cek field tambahan',
+    description: 'Lengkapi field baru yang ditambahkan oleh tim HR.'
+  }
+])
+
+const recentTitle = 'Sorotan biodata Anda'
+const recentSubtitle = 'Pantau informasi penting yang perlu dijaga tetap mutakhir.'
+</script>

--- a/src/views/EmployeeDashboard.vue
+++ b/src/views/EmployeeDashboard.vue
@@ -12,16 +12,18 @@
     quick-actions-title="Butuh melakukan sesuatu?"
     accent-color="#1f3c88"
     greeting="Hai, berikut ringkasan biodata Anda!"
+    overview-key="overview"
+    v-model:active-menu-key="activeMenu"
     @logout="handleLogout"
   >
-    <template #content>
+    <template #biodata>
       <EmployeeProfilePanel :email="sessionUser?.email || ''" />
     </template>
   </DashboardLayout>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import DashboardLayout from '../components/DashboardLayout.vue'
@@ -44,10 +46,11 @@ const handleLogout = () => {
   router.push('/login')
 }
 
+const activeMenu = ref('overview')
+
 const menuItems = [
-  { label: 'Beranda', helper: 'Ringkasan biodata' },
-  { label: 'Biodata', helper: 'Perbarui informasi Anda' },
-  { label: 'Field Tambahan', helper: 'Lengkapi permintaan HR' }
+  { key: 'overview', label: 'Beranda', helper: 'Ringkasan biodata' },
+  { key: 'biodata', label: 'Biodata', helper: 'Perbarui informasi Anda' }
 ]
 
 const { customFields, getEmployeeByEmail } = useEmployeeStore()

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,511 @@
+<template>
+  <div class="page">
+    <div class="background-gradient"></div>
+    <div class="background-accent background-accent--one"></div>
+    <div class="background-accent background-accent--two"></div>
+
+    <section class="login-card" aria-labelledby="login-title">
+      <header class="login-card__header">
+        <img src="@/assets/amk-logo.svg" alt="Logo AMK" class="login-card__logo" />
+        <h1 id="login-title" style="color: #1E1E54;">AMK Portal</h1>
+        <p class="login-card__subtitle">Cek biodata dan slip gaji Anda dengan akses jauh lebih mudah</p>
+      </header>
+
+      <form class="login-form" @submit.prevent="handleSubmit">
+        <label class="login-form__field">
+          <span style="color: #1E1E54;  font-weight: bold;">Email</span>
+          <input
+            v-model="email"
+            type="email"
+            placeholder="nama@email.com"
+            autocomplete="email"
+            required
+          />
+        </label>
+
+        <label class="login-form__field">
+          <span style="color: #1E1E54; font-weight: bold;">Kata Sandi</span>
+          <div class="password-input">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              placeholder="Masukkan kata sandi"
+              autocomplete="current-password"
+              required
+            />
+            <button
+              type="button"
+              class="password-input__toggle"
+              :aria-label="showPassword ? 'Sembunyikan kata sandi' : 'Tampilkan kata sandi'"
+              :title="showPassword ? 'Sembunyikan kata sandi' : 'Tampilkan kata sandi'"
+              :aria-pressed="showPassword ? 'true' : 'false'"
+              @click="togglePassword"
+            >
+              <!-- Eye (show) -->
+              <svg
+                v-if="!showPassword"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+
+              <!-- Eye off (hide) -->
+              <svg
+                v-else
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="22"
+                height="22"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.5 21.5 0 0 1 5.06-5.94" />
+                <path d="M1 1l22 22" />
+                <path d="M9.88 9.88A3 3 0 0 0 12 15a3 3 0 0 0 2.12-.88" />
+                <path d="M14.12 14.12 9.88 9.88" />
+                <path d="M22.94 12a21.5 21.5 0 0 0-5.06-5.94" />
+              </svg>
+            </button>
+          </div>
+        </label>
+
+        <div class="login-form__actions">
+          <label class="remember">
+            <input v-model="remember" type="checkbox" />
+            <span>Ingat saya</span>
+          </label>
+          <a href="#" class="link">Lupa kata sandi?</a>
+        </div>
+
+        <p v-if="errorMessage" class="login-form__error">{{ errorMessage }}</p>
+
+        <button type="submit" class="button button--primary" :disabled="isSubmitting">
+          {{ isSubmitting ? 'Memproses…' : 'Masuk' }}
+        </button>
+
+        <p class="login-form__help" style="font-weight: bold;">
+          Butuh bantuan?
+          <a
+            href="https://api.whatsapp.com/send/?phone=%2B6285173088119&text&type=phone_number&app_absent=0"
+            style="color:blue; font-style:italic; font-weight:bold;"
+            target="_blank"
+            rel="noopener"
+          >Klik Disini</a>
+        </p>
+      </form>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+import { ROLE_ROUTES, storeUserSession } from '../utils/auth'
+
+const router = useRouter()
+const route = useRoute()
+
+const email = ref('')
+const password = ref('')
+const remember = ref(false)
+const isSubmitting = ref(false)
+const showPassword = ref(false)
+const errorMessage = ref('')
+
+const dummyAccounts = [
+  {
+    email: 'admin@amk.com',
+    password: 'admin123',
+    role: 'admin',
+    name: 'Naufal Pratama',
+    position: 'Administrator HR'
+  },
+  {
+    email: 'pegawai@amk.com',
+    password: 'pegawai123',
+    role: 'pegawai',
+    name: 'Raisa Dewi',
+    position: 'Spesialis Marketing'
+  }
+]
+
+const togglePassword = () => {
+  showPassword.value = !showPassword.value
+}
+
+const handleSubmit = async () => {
+  if (isSubmitting.value) return
+
+  isSubmitting.value = true
+  errorMessage.value = ''
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const account = dummyAccounts.find(
+      (item) => item.email.toLowerCase() === email.value.toLowerCase() && item.password === password.value
+    )
+
+    if (!account) {
+      errorMessage.value = 'Email atau kata sandi salah. Silakan coba lagi.'
+      return
+    }
+
+    storeUserSession({
+      email: account.email,
+      role: account.role,
+      name: account.name,
+      position: account.position,
+      remember: remember.value
+    })
+
+    const redirectTarget = route.query.redirect
+    const targetPath =
+      typeof redirectTarget === 'string' && redirectTarget.length
+        ? redirectTarget
+        : ROLE_ROUTES[account.role] || '/login'
+
+    await router.push(targetPath)
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  background: linear-gradient(160deg, #071f3d 0%, #0b2c59 45%, #154e8a 100%);
+  overflow: hidden;
+}
+
+.background-gradient {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.1), transparent 55%),
+    radial-gradient(circle at bottom, rgba(21, 78, 138, 0.35), transparent 60%);
+  opacity: 0.85;
+}
+
+.background-accent {
+  position: absolute;
+  width: clamp(180px, 32vw, 340px);
+  height: clamp(180px, 32vw, 340px);
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.6;
+  z-index: 1;
+}
+
+.background-accent--one {
+  top: clamp(-80px, -6vw, -40px);
+  right: clamp(-60px, -8vw, -20px);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.background-accent--two {
+  bottom: clamp(-90px, -8vw, -30px);
+  left: clamp(-90px, -8vw, -30px);
+  background: rgba(36, 126, 214, 0.45);
+}
+
+.login-card {
+  position: relative;
+  z-index: 2;
+  width: min(420px, 100%);
+  padding: clamp(2rem, 4vw, 3rem);
+  background: linear-gradient(180deg, #ffffff 0%, #f5f7fa 100%);
+  border-radius: 24px;
+  box-shadow: 0 24px 60px rgba(3, 15, 32, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.login-card__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.login-card__logo {
+  width: clamp(60px, 14vw, 88px);
+  height: auto;
+}
+
+.login-card__header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 700;
+  color: #0a2245;
+  letter-spacing: -0.02em;
+}
+
+.login-card__subtitle {
+  color: rgba(9, 35, 70, 0.75);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: rgba(9, 35, 70, 0.78);
+  font-size: 0.95rem;
+}
+
+.login-form__field input[type='email'],
+.login-form__field input[type='password'],
+.password-input input[type='text'] {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(9, 35, 70, 0.12);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #091f3a;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form__field input[type='email']:focus,
+.login-form__field input[type='password']:focus,
+.password-input input[type='text']:focus {
+  outline: none;
+  border-color: rgba(21, 78, 138, 0.5);
+  box-shadow: 0 0 0 4px rgba(21, 78, 138, 0.15);
+}
+
+.password-input {
+  position: relative;
+  display: flex;
+}
+
+.password-input input {
+  flex: 1;
+}
+
+.password-input__toggle {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  color: rgba(9, 35, 70, 0.6);
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.25rem;
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+}
+
+.password-input__toggle:focus-visible {
+  outline: 2px solid rgba(21, 78, 138, 0.5);
+  outline-offset: 2px;
+}
+
+.password-input__toggle svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.login-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.login-form__error {
+  margin: -0.25rem 0 0;
+  color: #d93025;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.remember {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(9, 35, 70, 0.75);
+}
+
+.remember input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #154e8a;
+}
+
+.button {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.95rem 1.5rem;
+  border-radius: 16px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #0b2c59 0%, #154e8a 100%);
+  color: #ffffff;
+  box-shadow: 0 18px 40px rgba(11, 44, 89, 0.35);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 48px rgba(11, 44, 89, 0.4);
+}
+
+.button--primary:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(11, 44, 89, 0.3);
+}
+
+.button[disabled] {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.login-form__help {
+  text-align: center;
+  color: rgba(9, 35, 70, 0.7);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.link {
+  color: #154e8a;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .page {
+    padding: 2rem;
+  }
+
+  .login-card {
+    padding: 2.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 1.5rem;
+  }
+
+  .background-accent {
+    width: clamp(140px, 40vw, 220px);
+    height: clamp(140px, 40vw, 220px);
+    filter: blur(45px);
+  }
+
+  .login-card {
+    padding: 1.85rem;
+    border-radius: 20px;
+    gap: 1.5rem;
+  }
+
+  .login-card__subtitle {
+    font-size: 0.9rem;
+  }
+
+  .login-form__actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .button {
+    padding: 0.85rem 1.25rem;
+    border-radius: 14px;
+  }
+}
+
+@media (max-width: 420px) {
+  .page {
+    padding: 1.25rem;
+  }
+
+  .login-card {
+    padding: 1.65rem;
+  }
+
+  .login-card__header h1 {
+    font-size: 1.65rem;
+  }
+
+  .login-card__subtitle {
+    font-size: 0.85rem;
+  }
+
+  .login-form__field span {
+    font-size: 0.85rem;
+  }
+
+  .login-form__field input[type='email'],
+  .login-form__field input[type='password'],
+  .password-input input[type='text'] {
+    padding: 0.8rem 0.9rem;
+    font-size: 0.95rem;
+  }
+
+  .password-input__toggle {
+    right: 0.6rem;
+    font-size: 0.8rem;
+  }
+
+  .remember span,
+  .login-form__help,
+  .link,
+  .login-form__actions {
+    font-size: 0.85rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add a reusable employeeStore that seeds demo records, persists localStorage updates, and manages dynamic custom biodata fields
- embed a searchable, paginated CRUD table with modal forms and custom-field creation into the admin dashboard while refreshing the overview metrics to reflect live data
- expose a biodata editor for employees with completion tracking and integrate a dashboard layout slot so both roles share the navy styling while rendering their role-specific tools, plus document the local data flow in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68df494b0c788321b54389ee41a44382